### PR TITLE
test: Migrate assertions to AwesomeAssertions for improved readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ dotnet husky install
 # Build and test
 dotnet build
 dotnet test
+
+Tests use **xUnit** with **AwesomeAssertions** for fluent, readable assertions.
 ```
 
 ### Pre-commit Hooks

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -17,10 +17,13 @@ Test JSON parsing and markdown generation end-to-end. As the application is dist
 ## Test Infrastructure
 
 - **Framework**: xUnit 2.9.3
+- **Assertion Library**: AwesomeAssertions (fluent-style assertions)
 - **Test SDK**: Microsoft.NET.Test.Sdk 17.14.1
 - **Coverage**: Coverlet 6.0.4
 - **Skippable Tests**: Xunit.SkippableFact 1.5.23 (for conditional test execution when Docker is unavailable)
 - **Shared Fixtures**: `DockerFixture` provides a shared Docker container context for integration tests using xUnit's `IAsyncLifetime` and `ICollectionFixture`
+
+> Note: Tests were migrated from `xUnit.Assert` to `AwesomeAssertions` to improve readability and expressiveness of test assertions.
 
 ## Test Data
 

--- a/tests/Oocx.TfPlan2Md.Tests/Docker/DockerIntegrationTests.cs
+++ b/tests/Oocx.TfPlan2Md.Tests/Docker/DockerIntegrationTests.cs
@@ -1,3 +1,5 @@
+using AwesomeAssertions;
+
 namespace Oocx.TfPlan2Md.Tests.Docker;
 
 [Collection(nameof(DockerCollection))]
@@ -24,10 +26,10 @@ public class DockerIntegrationTests
 
         var (exitCode, stdout, stderr) = await _fixture.RunContainerAsync(TestDataPath);
 
-        Assert.Equal(0, exitCode);
-        Assert.Empty(stderr);
-        Assert.Contains("# Terraform Plan", stdout);
-        Assert.Contains("azurerm_resource_group.main", stdout);
+        exitCode.Should().Be(0);
+        stderr.Should().BeEmpty();
+        stdout.Should().Contain("# Terraform Plan");
+        stdout.Should().Contain("azurerm_resource_group.main");
     }
 
     [SkippableFact]
@@ -38,10 +40,10 @@ public class DockerIntegrationTests
         var json = await File.ReadAllTextAsync(TestDataPath);
         var (exitCode, stdout, stderr) = await _fixture.RunContainerWithStdinAsync(json);
 
-        Assert.Equal(0, exitCode);
-        Assert.Empty(stderr);
-        Assert.Contains("# Terraform Plan", stdout);
-        Assert.Contains("azurerm_resource_group.main", stdout);
+        exitCode.Should().Be(0);
+        stderr.Should().BeEmpty();
+        stdout.Should().Contain("# Terraform Plan");
+        stdout.Should().Contain("azurerm_resource_group.main");
     }
 
     [SkippableFact]
@@ -51,10 +53,10 @@ public class DockerIntegrationTests
 
         var (exitCode, stdout, stderr) = await _fixture.RunContainerWithStdinAsync("", ["--help"]);
 
-        Assert.Equal(0, exitCode);
-        Assert.Empty(stderr);
-        Assert.Contains("tfplan2md", stdout);
-        Assert.Contains("--help", stdout);
+        exitCode.Should().Be(0);
+        stderr.Should().BeEmpty();
+        stdout.Should().Contain("tfplan2md");
+        stdout.Should().Contain("--help");
     }
 
     [SkippableFact]
@@ -64,9 +66,9 @@ public class DockerIntegrationTests
 
         var (exitCode, stdout, stderr) = await _fixture.RunContainerWithStdinAsync("", ["--version"]);
 
-        Assert.Equal(0, exitCode);
-        Assert.Empty(stderr);
-        Assert.Contains("tfplan2md", stdout);
+        exitCode.Should().Be(0);
+        stderr.Should().BeEmpty();
+        stdout.Should().Contain("tfplan2md");
     }
 
     [SkippableFact]
@@ -76,8 +78,8 @@ public class DockerIntegrationTests
 
         var (exitCode, _, stderr) = await _fixture.RunContainerWithStdinAsync("{ invalid json }");
 
-        Assert.NotEqual(0, exitCode);
-        Assert.Contains("Error", stderr);
+        exitCode.Should().NotBe(0);
+        stderr.Should().Contain("Error");
     }
 
     [SkippableFact]
@@ -87,13 +89,9 @@ public class DockerIntegrationTests
 
         var (exitCode, stdout, stderr) = await _fixture.RunContainerAsync(TestDataPath);
 
-        Assert.Equal(0, exitCode);
-        Assert.Empty(stderr);
+        exitCode.Should().Be(0);
+        stderr.Should().BeEmpty();
         // Verify expected resources from the test data are in the output
-        Assert.Contains("azurerm_resource_group.main", stdout);
-        Assert.Contains("azurerm_key_vault.main", stdout);
-        Assert.Contains("azurerm_virtual_network.old", stdout);
-        Assert.Contains("azuredevops_project.main", stdout);
-        Assert.Contains("azuredevops_git_repository.main", stdout);
+        stdout.Should().Contain("azurerm_resource_group.main").And.Contain("azurerm_key_vault.main").And.Contain("azurerm_virtual_network.old").And.Contain("azuredevops_project.main").And.Contain("azuredevops_git_repository.main");
     }
 }

--- a/tests/Oocx.TfPlan2Md.Tests/MarkdownGeneration/MarkdownRendererTests.cs
+++ b/tests/Oocx.TfPlan2Md.Tests/MarkdownGeneration/MarkdownRendererTests.cs
@@ -328,9 +328,8 @@ public class MarkdownRendererTests
         var result = _renderer.RenderResourceChange(firewallChange);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Contains("web_tier", result);
-        Assert.Contains("Rule Changes", result);
+        result.Should().NotBeNull();
+        result.Should().Contain("web_tier").And.Contain("Rule Changes");
     }
 
     [Fact]
@@ -347,9 +346,8 @@ public class MarkdownRendererTests
         var result = _renderer.RenderResourceChange(firewallChange);
 
         // Assert - allow-dns was added
-        Assert.NotNull(result);
-        Assert.Contains("allow-dns", result);
-        Assert.Contains("➕", result);
+        result.Should().NotBeNull();
+        result.Should().Contain("allow-dns").And.Contain("➕");
     }
 
     [Fact]
@@ -366,9 +364,8 @@ public class MarkdownRendererTests
         var result = _renderer.RenderResourceChange(firewallChange);
 
         // Assert - allow-http was modified (source_addresses changed)
-        Assert.NotNull(result);
-        Assert.Contains("allow-http", result);
-        Assert.Contains("🔄", result);
+        result.Should().NotBeNull();
+        result.Should().Contain("allow-http").And.Contain("🔄");
     }
 
     [Fact]
@@ -385,9 +382,8 @@ public class MarkdownRendererTests
         var result = _renderer.RenderResourceChange(firewallChange);
 
         // Assert - allow-ssh-old was removed
-        Assert.NotNull(result);
-        Assert.Contains("allow-ssh-old", result);
-        Assert.Contains("❌", result);
+        result.Should().NotBeNull();
+        result.Should().Contain("allow-ssh-old").And.Contain("❌");
     }
 
     [Fact]
@@ -404,9 +400,8 @@ public class MarkdownRendererTests
         var result = _renderer.RenderResourceChange(firewallChange);
 
         // Assert - allow-https was unchanged
-        Assert.NotNull(result);
-        Assert.Contains("allow-https", result);
-        Assert.Contains("⏺️", result);
+        result.Should().NotBeNull();
+        result.Should().Contain("allow-https").And.Contain("⏺️");
     }
 
     [Fact]
@@ -423,12 +418,8 @@ public class MarkdownRendererTests
         var result = _renderer.RenderResourceChange(firewallChange);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Contains("database-tier-rules", result);
-        Assert.Contains("allow-sql", result);
-        Assert.Contains("allow-mysql", result);
-        Assert.Contains("1433", result);
-        Assert.Contains("3306", result);
+        result.Should().NotBeNull();
+        result.Should().Contain("database-tier-rules").And.Contain("allow-sql").And.Contain("allow-mysql").And.Contain("1433").And.Contain("3306");
     }
 
     [Fact]
@@ -445,10 +436,8 @@ public class MarkdownRendererTests
         var result = _renderer.RenderResourceChange(firewallChange);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Contains("legacy-rules", result);
-        Assert.Contains("allow-ftp", result);
-        Assert.Contains("being deleted", result);
+        result.Should().NotBeNull();
+        result.Should().Contain("legacy-rules").And.Contain("allow-ftp").And.Contain("being deleted");
     }
 
     [Fact]
@@ -465,7 +454,7 @@ public class MarkdownRendererTests
         var result = _renderer.RenderResourceChange(resourceGroup);
 
         // Assert - No resource-specific template exists, should return null
-        Assert.Null(result);
+        result.Should().BeNull();
     }
 
     [Fact]
@@ -482,16 +471,11 @@ public class MarkdownRendererTests
         var result = _renderer.RenderResourceChange(firewallChange);
 
         // Assert - Should contain table headers including Description
-        Assert.NotNull(result);
-        Assert.Contains("Rule Name", result);
-        Assert.Contains("Description", result);
-        Assert.Contains("Protocols", result);
-        Assert.Contains("Source Addresses", result);
-        Assert.Contains("Destination Addresses", result);
-        Assert.Contains("Destination Ports", result);
+        result.Should().NotBeNull();
+        result.Should().Contain("Rule Name").And.Contain("Description").And.Contain("Protocols").And.Contain("Source Addresses").And.Contain("Destination Addresses").And.Contain("Destination Ports");
 
         // Assert - Should contain actual description content
-        Assert.Contains("Allow HTTPS traffic", result);
+        result.Should().Contain("Allow HTTPS traffic");
     }
 
     [Fact]
@@ -508,10 +492,8 @@ public class MarkdownRendererTests
         var result = _renderer.RenderResourceChange(firewallChange);
 
         // Assert - Modified rule details should be in collapsible section
-        Assert.NotNull(result);
-        Assert.Contains("<details>", result);
-        Assert.Contains("Modified Rule Details", result);
-        Assert.Contains("</details>", result);
+        result.Should().NotBeNull();
+        result.Should().Contain("<details>").And.Contain("Modified Rule Details").And.Contain("</details>");
     }
 
     #endregion

--- a/tests/Oocx.TfPlan2Md.Tests/MarkdownGeneration/ScribanHelpersTests.cs
+++ b/tests/Oocx.TfPlan2Md.Tests/MarkdownGeneration/ScribanHelpersTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using AwesomeAssertions;
 using Oocx.TfPlan2Md.MarkdownGeneration;
 using Scriban.Runtime;
 
@@ -29,10 +30,10 @@ public class ScribanHelpersTests
 
         // Assert
         var added = result["added"] as ScriptArray;
-        Assert.NotNull(added);
-        Assert.Single(added);
+        added.Should().NotBeNull();
+        added.Should().ContainSingle();
         var addedItem = added[0] as ScriptObject;
-        Assert.Equal("rule2", addedItem?["name"]);
+        addedItem?["name"].Should().Be("rule2");
     }
 
     [Fact]
@@ -57,10 +58,10 @@ public class ScribanHelpersTests
 
         // Assert
         var removed = result["removed"] as ScriptArray;
-        Assert.NotNull(removed);
-        Assert.Single(removed);
+        removed.Should().NotBeNull();
+        removed.Should().ContainSingle();
         var removedItem = removed[0] as ScriptObject;
-        Assert.Equal("rule2", removedItem?["name"]);
+        removedItem?["name"].Should().Be("rule2");
     }
 
     [Fact]
@@ -84,17 +85,17 @@ public class ScribanHelpersTests
 
         // Assert
         var modified = result["modified"] as ScriptArray;
-        Assert.NotNull(modified);
-        Assert.Single(modified);
+        modified.Should().NotBeNull();
+        modified.Should().ContainSingle();
 
         var modifiedItem = modified[0] as ScriptObject;
-        Assert.NotNull(modifiedItem);
+        modifiedItem.Should().NotBeNull();
 
         var before = modifiedItem["before"] as ScriptObject;
         var after = modifiedItem["after"] as ScriptObject;
 
-        Assert.Equal(80L, Convert.ToInt64(before?["port"], CultureInfo.InvariantCulture));
-        Assert.Equal(8080L, Convert.ToInt64(after?["port"], CultureInfo.InvariantCulture));
+        Convert.ToInt64(before?["port"], CultureInfo.InvariantCulture).Should().Be(80L);
+        Convert.ToInt64(after?["port"], CultureInfo.InvariantCulture).Should().Be(8080L);
     }
 
     [Fact]
@@ -118,14 +119,14 @@ public class ScribanHelpersTests
 
         // Assert
         var unchanged = result["unchanged"] as ScriptArray;
-        Assert.NotNull(unchanged);
-        Assert.Single(unchanged);
+        unchanged.Should().NotBeNull();
+        unchanged.Should().ContainSingle();
         var unchangedItem = unchanged[0] as ScriptObject;
-        Assert.Equal("rule1", unchangedItem?["name"]);
+        unchangedItem?["name"].Should().Be("rule1");
 
-        Assert.Empty((ScriptArray)result["added"]!);
-        Assert.Empty((ScriptArray)result["removed"]!);
-        Assert.Empty((ScriptArray)result["modified"]!);
+        ((ScriptArray)result["added"]!).Should().BeEmpty();
+        ((ScriptArray)result["removed"]!).Should().BeEmpty();
+        ((ScriptArray)result["modified"]!).Should().BeEmpty();
     }
 
     [Fact]
@@ -152,10 +153,10 @@ public class ScribanHelpersTests
         var result = ScribanHelpers.DiffArray(beforeJson, afterJson, "name");
 
         // Assert
-        Assert.Single((ScriptArray)result["added"]!);
-        Assert.Single((ScriptArray)result["removed"]!);
-        Assert.Single((ScriptArray)result["modified"]!);
-        Assert.Single((ScriptArray)result["unchanged"]!);
+        ((ScriptArray)result["added"]!).Should().ContainSingle();
+        ((ScriptArray)result["removed"]!).Should().ContainSingle();
+        ((ScriptArray)result["modified"]!).Should().ContainSingle();
+        ((ScriptArray)result["unchanged"]!).Should().ContainSingle();
     }
 
     [Fact]
@@ -173,10 +174,10 @@ public class ScribanHelpersTests
         var result = ScribanHelpers.DiffArray(beforeJson, afterJson, "name");
 
         // Assert
-        Assert.Single((ScriptArray)result["added"]!);
-        Assert.Empty((ScriptArray)result["removed"]!);
-        Assert.Empty((ScriptArray)result["modified"]!);
-        Assert.Empty((ScriptArray)result["unchanged"]!);
+        ((ScriptArray)result["added"]!).Should().ContainSingle();
+        ((ScriptArray)result["removed"]!).Should().BeEmpty();
+        ((ScriptArray)result["modified"]!).Should().BeEmpty();
+        ((ScriptArray)result["unchanged"]!).Should().BeEmpty();
     }
 
     [Fact]
@@ -194,10 +195,10 @@ public class ScribanHelpersTests
         var result = ScribanHelpers.DiffArray(beforeJson, afterJson, "name");
 
         // Assert
-        Assert.Empty((ScriptArray)result["added"]!);
-        Assert.Single((ScriptArray)result["removed"]!);
-        Assert.Empty((ScriptArray)result["modified"]!);
-        Assert.Empty((ScriptArray)result["unchanged"]!);
+        ((ScriptArray)result["added"]!).Should().BeEmpty();
+        ((ScriptArray)result["removed"]!).Should().ContainSingle();
+        ((ScriptArray)result["modified"]!).Should().BeEmpty();
+        ((ScriptArray)result["unchanged"]!).Should().BeEmpty();
     }
 
     [Fact]
@@ -214,8 +215,8 @@ public class ScribanHelpersTests
         var result = ScribanHelpers.DiffArray(null, afterJson, "name");
 
         // Assert
-        Assert.Single((ScriptArray)result["added"]!);
-        Assert.Empty((ScriptArray)result["removed"]!);
+        ((ScriptArray)result["added"]!).Should().ContainSingle();
+        ((ScriptArray)result["removed"]!).Should().BeEmpty();
     }
 
     [Fact]
@@ -232,8 +233,8 @@ public class ScribanHelpersTests
         var result = ScribanHelpers.DiffArray(beforeJson, null, "name");
 
         // Assert
-        Assert.Empty((ScriptArray)result["added"]!);
-        Assert.Single((ScriptArray)result["removed"]!);
+        ((ScriptArray)result["added"]!).Should().BeEmpty();
+        ((ScriptArray)result["removed"]!).Should().ContainSingle();
     }
 
     [Fact]
@@ -253,12 +254,9 @@ public class ScribanHelpersTests
             """).RootElement;
 
         // Act & Assert
-        var ex = Assert.Throws<ScribanHelperException>(() =>
-            ScribanHelpers.DiffArray(beforeJson, afterJson, "name"));
-
-        Assert.Contains("missing required key property 'name'", ex.Message);
-        Assert.Contains("index 0", ex.Message);
-        Assert.Contains("'after'", ex.Message);
+        Action act = () => ScribanHelpers.DiffArray(beforeJson, afterJson, "name");
+        act.Should().Throw<ScribanHelperException>()
+            .Which.Message.Should().Contain("missing required key property 'name'").And.Contain("index 0").And.Contain("'after'");
     }
 
     [Fact]
@@ -282,8 +280,8 @@ public class ScribanHelpersTests
 
         // Assert
         var modified = result["modified"] as ScriptArray;
-        Assert.NotNull(modified);
-        Assert.Single(modified);
+        modified.Should().NotBeNull();
+        modified.Should().ContainSingle();
     }
 
     [Fact]
@@ -307,8 +305,8 @@ public class ScribanHelpersTests
 
         // Assert
         var modified = result["modified"] as ScriptArray;
-        Assert.NotNull(modified);
-        Assert.Single(modified);
+        modified.Should().NotBeNull();
+        modified.Should().ContainSingle();
     }
 
     [Fact]
@@ -321,6 +319,6 @@ public class ScribanHelpersTests
         ScribanHelpers.RegisterHelpers(scriptObject);
 
         // Assert
-        Assert.True(scriptObject.ContainsKey("diff_array"));
+        scriptObject.ContainsKey("diff_array").Should().BeTrue();
     }
 }


### PR DESCRIPTION
Migrate test assertions from `xUnit.Assert` to `AwesomeAssertions` to enhance the readability and expressiveness of the tests. Update documentation to reflect this change.