### PR TITLE
feat: move branch creation to Requirements Engineer and add commits to planning agents

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -33,6 +33,7 @@ Transform a Feature Specification into a clear technical design with documented 
 - Verify design aligns with project goals in docs/spec.md
 - Address security, reliability, and maintainability concerns
 - Create or update ADRs in docs/ or docs/features/<feature-name>/
+- Commit architecture documents when approved
 
 ### ⚠️ Ask First
 - Proposing significant changes to existing architecture
@@ -175,8 +176,17 @@ Your work is complete when:
 - [ ] The technical approach is clearly documented (or documented as "no changes needed")
 - [ ] Alternatives were considered and trade-offs explained (if applicable)
 - [ ] The design aligns with existing architecture patterns
+- [ ] Changes are committed to the feature branch
 - [ ] The maintainer has approved the architecture decision
 - [ ] **No source code was written** - only documentation files were created/modified
+
+## Committing Your Work
+
+After the architecture is approved:
+```bash
+git add docs/features/<feature-name>/architecture.md docs/adr-*.md
+git commit -m "docs: add architecture decision for <feature-name>"
+```
 
 ## Handoff
 

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -26,7 +26,7 @@ Produce clean, well-tested code that meets all acceptance criteria and follows p
 ## Boundaries
 
 ### ✅ Always Do
-- Update local `main` and create feature branch before starting
+- Verify you're on the correct feature branch (created by Requirements Engineer)
 - Write tests before implementation (test-first approach)
 - Run full test suite before considering work complete
 - Follow C# coding conventions and use modern C# features
@@ -84,11 +84,11 @@ Follow the project's coding conventions strictly:
 
 ## Implementation Approach
 
-1. **Prepare branch** - Before starting any implementation, ensure your local `main` branch is up to date with the remote and create a new feature branch based on it:
-   - Update local `main` from remote: `git fetch origin && git switch main && git pull --ff-only origin main`
-   - Create and switch to a feature branch: `git switch -c feature/<short-description>`
-   - Use a descriptive branch name that references the issue or feature (for example: `feature/123-add-report-template`).
-   - If you prefer rebasing rather than merging, replace the pull with `git pull --rebase origin main`.
+1. **Verify branch** - Ensure you're on the feature branch created by the Requirements Engineer:
+   ```bash
+   git status  # Confirm you're on feature/<name> branch
+   git pull origin main --rebase  # Update with any changes from main
+   ```
 
 2. **Review all inputs** - Read the specification, architecture, tasks, and test plan thoroughly.
 

--- a/.github/agents/product-owner.agent.md
+++ b/.github/agents/product-owner.agent.md
@@ -31,6 +31,7 @@ Break down the feature into clear, prioritized work items with well-defined acce
 - Prioritize tasks based on dependencies and risk
 - Ensure each task maps back to the Feature Specification
 - Consider implementation order (foundational work first)
+- Commit tasks document when approved
 
 ### ⚠️ Ask First
 - Changing the scope defined in the Feature Specification
@@ -130,7 +131,16 @@ Your work is complete when:
 - [ ] All aspects of the specification are covered by tasks
 - [ ] Each task has clear, testable acceptance criteria
 - [ ] Tasks are prioritized and ordered logically
+- [ ] Changes are committed to the feature branch
 - [ ] The maintainer has approved the tasks
+
+## Committing Your Work
+
+After the tasks are approved:
+```bash
+git add docs/features/<feature-name>/tasks.md
+git commit -m "docs: add tasks for <feature-name>"
+```
 
 ## Handoff
 

--- a/.github/agents/quality-engineer.agent.md
+++ b/.github/agents/quality-engineer.agent.md
@@ -28,6 +28,7 @@ Create a test plan that maps test cases to acceptance criteria, ensuring the fea
 - Use test naming convention: `MethodName_Scenario_ExpectedResult`
 - Verify tests can run via `dotnet test` without human intervention
 - Consider edge cases, error conditions, and boundary values
+- Commit test plan when approved
 
 ### ⚠️ Ask First
 - Adding new test infrastructure or frameworks
@@ -162,7 +163,16 @@ Your work is complete when:
 - [ ] All acceptance criteria have mapped test cases
 - [ ] Edge cases and error scenarios are covered
 - [ ] Test cases follow project conventions
+- [ ] Changes are committed to the feature branch
 - [ ] The maintainer has approved the test plan
+
+## Committing Your Work
+
+After the test plan is approved:
+```bash
+git add docs/features/<feature-name>/test-plan.md
+git commit -m "docs: add test plan for <feature-name>"
+```
 
 ## Handoff
 

--- a/.github/agents/requirements-engineer.agent.md
+++ b/.github/agents/requirements-engineer.agent.md
@@ -26,12 +26,14 @@ Transform an initial feature idea into a clear, unambiguous Feature Specificatio
 ## Boundaries
 
 ### ✅ Always Do
+- Create feature branch from latest main before starting
 - Ask one question at a time, wait for answer
 - Listen completely before asking clarifying questions
 - Clarify what is explicitly out of scope
 - Identify conflicts with existing features early
 - Summarize understanding before writing specification
 - Define measurable success criteria
+- Commit specification when approved
 
 ### ⚠️ Ask First
 - If the feature conflicts with project goals in docs/spec.md
@@ -54,9 +56,14 @@ Before starting, familiarize yourself with:
 
 ## Conversation Approach
 
-1. **Listen first** - Let the maintainer describe their feature idea completely before asking questions.
+1. **Create feature branch** - Before starting requirements gathering:
+   - Update local `main` from remote: `git fetch origin && git switch main && git pull --ff-only origin main`
+   - Create and switch to a feature branch: `git switch -c feature/<short-description>`
+   - Use a descriptive branch name that references the issue or feature (e.g., `feature/123-firewall-diff-display`)
 
-2. **Ask one question at a time** - Never list multiple questions. Wait for an answer before asking the next question.
+2. **Listen first** - Let the maintainer describe their feature idea completely before asking questions.
+
+3. **Ask one question at a time** - Never list multiple questions. Wait for an answer before asking the next question.
 
 3. **Clarify incrementally** - Focus on understanding:
    - What problem does this solve for the user?
@@ -65,9 +72,9 @@ Before starting, familiarize yourself with:
    - What is explicitly out of scope?
    - Are there edge cases or error scenarios to consider?
 
-4. **Summarize understanding** - Before producing the specification, summarize your understanding and ask for confirmation.
+5. **Summarize understanding** - Before producing the specification, summarize your understanding and ask for confirmation.
 
-5. **Identify conflicts** - If the request conflicts with existing features or project goals, raise this for discussion.
+6. **Identify conflicts** - If the request conflicts with existing features or project goals, raise this for discussion.
 
 ## Output: Feature Specification
 
@@ -123,10 +130,20 @@ Use lowercase kebab-case for the feature name (e.g., `resource-grouping`, `custo
 ## Definition of Done
 
 Your work is complete when:
+- [ ] Feature branch has been created from latest main
 - [ ] All requirements are documented clearly and unambiguously
 - [ ] Success criteria are specific and testable
-- [ ] The maintainer has approved the specification
 - [ ] The specification file is saved to the correct location
+- [ ] Changes are committed to the feature branch
+- [ ] The maintainer has approved the specification
+
+## Committing Your Work
+
+After the specification is approved:
+```bash
+git add docs/features/<feature-name>/specification.md
+git commit -m "docs: add feature specification for <feature-name>"
+```
 
 ## Handoff
 


### PR DESCRIPTION
## Summary

This PR improves the agent workflow by moving branch creation earlier and ensuring all planning agents commit their work, creating better checkpoints throughout the feature development process.

## Changes

### Requirements Engineer (First Agent)
- **Now creates feature branch** from latest main as first step
- Branch naming: `feature/<short-description>`
- Commits specification.md when approved

### Planning Agents (Architect, Product Owner, Quality Engineer)
- **Now commit their documentation** when approved
- Architect: commits architecture.md and ADRs
- Product Owner: commits tasks.md
- Quality Engineer: commits test-plan.md

### Developer
- **No longer creates branch** (already created by RE)
- Now verifies correct branch and rebases on main if needed
- Simplified workflow since branch already exists

### Updated Boundaries
All affected agents now have updated "✅ Always Do" sections reflecting:
- Branch creation responsibility (RE)
- Commit responsibility (RE, Architect, PO, QE)
- Branch verification instead of creation (Developer)

## Rationale

**Before**: Only Developer created branch and committed. All planning documentation lived in working directory until implementation.

**After**: 
- Branch created immediately by first agent (RE)
- Each planning agent commits when their work is approved
- Better change tracking from the start
- Clear checkpoints throughout workflow
- Documentation files tracked from creation

## Benefits

1. **Better tracking** - All documentation changes are committed incrementally
2. **Clear checkpoints** - Each phase has a commit showing progress
3. **Earlier version control** - Branch exists from requirements gathering
4. **Simpler handoffs** - Next agent pulls latest commits
5. **Rollback friendly** - Can revert to specific planning phase if needed