### PR TITLE
fix: improve agent reliability and workflow consistency

### DIFF
--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -63,10 +63,17 @@ This project uses:
 - Do NOT edit `CHANGELOG.md` manually - Versionize generates it automatically
 - Version bumping is handled by Versionize based on conventional commits
 - The CI pipeline builds and publishes the Docker image
+- **CRITICAL**: For instructions on how to use the GitHub CLI (`gh`) in automated agents, refer to the [.github/gh-cli-instructions.md](.github/gh-cli-instructions.md) file. Always use `PAGER=cat` prefix or export `GH_PAGER=cat` to prevent interactive pagers from blocking execution
 
 ## Pre-Release Checklist
 
 Before releasing, verify:
+
+0. **Prevent gh CLI blocking** (run once per session):
+   ```bash
+   export GH_PAGER=cat
+   export GH_FORCE_TTY=false
+   ```
 
 1. **Code Review Approved**
    - [ ] Code review report shows "Approved" status
@@ -103,7 +110,7 @@ Before releasing, verify:
 
 2. **Review commit history** - Ensure commits follow conventional commit format:
    ```bash
-   git log --oneline origin/main..HEAD
+   PAGER=cat git log --oneline origin/main..HEAD
    ```
 
 3. **Create Pull Request**:
@@ -125,13 +132,13 @@ Before releasing, verify:
 
 6. **Trigger Release Workflow** (after confirmation):
    ```bash
-   gh workflow run release.yml
+   PAGER=cat gh workflow run release.yml
    ```
 
 7. **Monitor Release Pipeline** - Watch the GitHub Actions pipeline:
    ```bash
-   gh run list --workflow=release.yml --limit 1
-   gh run watch
+   PAGER=cat gh run list --workflow=release.yml --limit 1
+   PAGER=cat gh run watch
    ```
    - If the release pipeline fails, hand off to Developer agent
 

--- a/.github/agents/support-engineer.agent.md
+++ b/.github/agents/support-engineer.agent.md
@@ -9,10 +9,6 @@ handoffs:
     agent: "Developer"
     prompt: Review the issue analysis above and implement the fix.
     send: false
-  - label: Hand off to Code Reviewer
-    agent: "Code Reviewer"
-    prompt: Review the issue analysis above and provide guidance on the fix approach.
-    send: false
 ---
 
 # Support Engineer Agent
@@ -153,9 +149,8 @@ Use descriptive names like:
 
 ### Step 6: Hand Off
 
-Use handoff buttons to transition to:
+Use handoff button to transition to:
 - **Developer** - For implementing the fix
-- **Code Reviewer** - For guidance on complex fixes
 
 ## Output: Issue Analysis Document
 
@@ -221,10 +216,10 @@ Your work is complete when:
 - [ ] Problem is clearly understood and documented
 - [ ] Root cause is identified
 - [ ] Diagnostic information is collected
-- [ ] Issue analysis document is created
+- [ ] Issue analysis document is **created and saved to disk** at `docs/issues/<issue-description>/analysis.md`
 - [ ] Issue branch is created from latest main
 - [ ] Analysis is committed to the branch
-- [ ] Ready to hand off to Developer or Code Reviewer
+- [ ] Ready to hand off to Developer
 
 ## Committing Your Work
 
@@ -238,7 +233,6 @@ git commit -m "docs: add issue analysis for <description>"
 - Stay focused on **diagnosis and analysis**, not implementation
 - If you find the fix is trivial, still document it and hand off to Developer
 - For complex issues, consider handing off to Code Reviewer for guidance first
-- If the issue reveals missing tests, note this in the analysis
 - If you're uncertain about the root cause, document what you've ruled out
 
 ## Examples

--- a/.github/agents/workflow-engineer.agent.md
+++ b/.github/agents/workflow-engineer.agent.md
@@ -17,6 +17,8 @@ Evolve and optimize the agent workflow by creating new agents, modifying existin
 ## Boundaries
 
 ### ✅ Always Do
+- **CRITICAL**: Before making any changes, ensure you're on an up-to-date feature branch, NOT main
+- Check current branch: `git branch --show-current` - if on main, STOP and create feature branch first
 - Update `docs/agents.md` whenever agents or workflow change
 - Use valid VS Code Copilot tool IDs (`readFile`, `listDirectory`, `editFile`, etc.)
 - Verify handoff agent names exist before committing
@@ -268,8 +270,20 @@ Before making modifications:
 - Ensure changes don't break existing functionality
 
 ### 5. Implement Incrementally
+
+**CRITICAL FIRST STEP - Check Branch Status:**
+```bash
+# Check what branch you're on
+git branch --show-current
+
+# If you're on main, STOP and create feature branch first:
+git fetch origin && git switch main && git pull --ff-only origin main
+git switch -c workflow/<description>
+
+# Only proceed after confirming you're on a feature branch
+```
+
 Make changes in small steps:
-- Create feature branch: `git switch -c workflow/<description>`
 - Modify agent files
 - Update `docs/agents.md`
 - Validate each step before next
@@ -317,13 +331,14 @@ When updating `docs/agents.md`, verify all of these:
 
 ### Creating a New Agent
 1. Research similar agents and best practices
-2. Define clear persona and specific goal
-3. Select appropriate model:
-   - Consult [docs/ai-model-reference.md](docs/ai-model-reference.md)
-   - Match model to agent's primary task categories
-   - Consider frequency and cost
-4. Choose minimal necessary tools (see Tool Selection Guide)
-5. Create `.github/agents/<name>.agent.md`
+2. **CRITICAL**: Check current branch with `git branch --show-current` - if on main, create feature branch FIRST
+2. Identify specific problem or gap
+3. Read current agent definition completely
+4. Consult [docs/ai-model-reference.md](docs/ai-model-reference.md) if model change considered
+5. Propose targeted improvement with data/rationale
+6. Test change doesn't break handoffs
+7. Update documentation if role/handoffs change
+8. Create `.github/agents/<name>.agent.md`
 6. Add comprehensive Boundaries section (✅/⚠️/🚫)
 7. Add to `docs/agents.md` (diagram, tables, descriptions)
 8. Commit and create PR

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -63,7 +63,6 @@ flowchart TB
 	HUMAN == "Workflow Improvement" ==> WE
 	SE -- "Produces" --> IA
 	IA -- "Consumed by" --> DEV
-	IA -- "Consumed by" --> CR
 	RE -- "Produces" --> FS
 	FS -- "Consumed by" --> AR
     FS -- "Consumed by" --> PO
@@ -220,7 +219,7 @@ Each agent hands off to the next by producing a specific deliverable. The follow
 
 | From Agent              | To Agent                | Handoff Trigger / Deliverable                        |
 |-------------------------|-------------------------|------------------------------------------------------|
-| Support Engineer        | Developer, Code Reviewer| Issue Analysis with root cause and fix approach      |
+| Support Engineer        | Developer               | Issue Analysis with root cause and fix approach      |
 | Requirements Engineer   | Architect (preferred), Product Owner (for simple features with no architecture changes) | Feature Specification |
 | Architect               | Product Owner, QE, DEV  | Architecture Decision Records (ADRs)                 |
 | Product Owner           | QE, DEV, DOC            | User Stories / Tasks with Acceptance Criteria        |


### PR DESCRIPTION
This PR improves the reliability of the Support Engineer, Release Manager, and Workflow Engineer agents.

Key changes:
- **Support Engineer**: Removed Code Reviewer handoff and emphasized saving analysis to disk.
- **Release Manager**: Added PAGER prevention and non-blocking gh CLI instructions.
- **Workflow Engineer**: Added critical branch checks to prevent working on main.
- **Documentation**: Updated docs/agents.md to reflect these changes.