### PR TITLE
feat: make Architect defer decisions to maintainer when multiple options exist

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -40,6 +40,8 @@ Transform a Feature Specification into a clear technical design with documented 
 - Consider multiple implementation approaches
 - Document trade-offs for each option clearly
 - Present your recommendation with rationale
+- **When multiple viable options exist, ask the maintainer to choose** (unless one option is clearly superior)
+- **When non-functional requirements conflict or priorities are unclear, ask the maintainer** (e.g., performance vs. simplicity trade-offs)
 - Verify design aligns with project goals in docs/spec.md
 - Address security, reliability, and maintainability concerns
 - Create or update ADRs in docs/ or docs/features/<feature-name>/
@@ -50,6 +52,8 @@ Transform a Feature Specification into a clear technical design with documented 
 - Introducing new frameworks, libraries, or patterns
 - Design decisions that affect multiple features
 - Non-functional requirements not specified (performance targets, etc.)
+- **Which option to choose when multiple reasonable alternatives exist**
+- **Priority of conflicting non-functional requirements** (performance vs. maintainability, etc.)
 
 ### 🚫 Never Do
 - Write implementation code (.cs, .csproj files)
@@ -87,7 +91,13 @@ Before starting, familiarize yourself with:
 
 4. **Ask one question at a time** - If clarification is needed from the maintainer, ask focused questions.
 
-5. **Propose before deciding** - Present your recommended approach and rationale before producing the final ADR.
+5. **Present options and get decision** - When you identify multiple viable implementation approaches:
+   - Present each option with pros and cons
+   - Provide a reasoned recommendation (clearly state which you recommend and why)
+   - **Ask the maintainer to make the final choice** (unless one option is objectively superior)
+   - If non-functional requirements conflict (e.g., performance vs. simplicity), ask about priorities
+
+6. **Document the chosen approach** - After the maintainer decides, produce the final ADR with the selected option.
 
 ## Output: Architecture Decision Record (ADR)
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -139,6 +139,7 @@ _Agents produce and consume artifacts. Arrows show artifact creation and consump
 ### 3. Architect
 - **Goal:** Design the technical solution and document decisions.
 - **Deliverables:** Architecture overview, ADRs, technology choices.
+- **Key Behavior:** When multiple viable options exist, presents pros/cons with a recommendation and asks maintainer to choose the final approach.
 - **Definition of Done:** Architecture is documented and approved.
 
 ### 4. Product Owner


### PR DESCRIPTION
This PR enhances the Architect agent to defer final decisions to the maintainer when multiple viable implementation options exist.

## Changes

- **Added decision deferral to boundaries**: Architect must ask maintainer to choose between options unless one is clearly superior
- **Ask about conflicting NFRs**: When non-functional requirements conflict or priorities are unclear, Architect asks maintainer for guidance
- **Updated conversation flow**: Added step to present options with pros/cons, provide recommendation, and get maintainer's decision
- **Documentation update**: Updated docs/agents.md to reflect this key behavior

## Impact

The Architect agent will now:
1. Present multiple viable options with trade-offs
2. Provide a reasoned recommendation
3. **Let the maintainer make the final choice**
4. Ask about priority when NFRs conflict (e.g., performance vs. simplicity)

## Motivation

Based on workflow observation during feature development, the Architect should empower the maintainer to make final architectural decisions rather than choosing unilaterally when multiple good options exist.