### PR TITLE
feat: update agent tools and fix relative paths

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -66,10 +66,10 @@ Transform a Feature Specification into a clear technical design with documented 
 
 Before starting, familiarize yourself with:
 - The Feature Specification in `docs/features/<feature-name>/specification.md` (created by the Requirements Engineer)
-- [docs/spec.md](docs/spec.md) - Project specification and technical constraints
-- [docs/architecture.md](docs/architecture.md) - Existing architecture overview
+- [docs/spec.md](../../docs/spec.md) - Project specification and technical constraints
+- [docs/architecture.md](../../docs/architecture.md) - Existing architecture overview
 - Existing ADRs in `docs/` (files matching `adr-*.md`) - Previous architecture decisions
-- [docs/agents.md](docs/agents.md) - Workflow overview and artifact formats
+- [docs/agents.md](../../docs/agents.md) - Workflow overview and artifact formats
 - Relevant source code in `src/` to understand current patterns
 
 ## Conversation Approach

--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -54,8 +54,8 @@ Before starting, familiarize yourself with:
 - The Architecture document in `docs/features/<feature-name>/architecture.md`
 - The Tasks document in `docs/features/<feature-name>/tasks.md`
 - The Test Plan in `docs/features/<feature-name>/test-plan.md`
-- [.github/copilot-instructions.md](.github/copilot-instructions.md) - Coding guidelines
-- [docs/testing-strategy.md](docs/testing-strategy.md) - Testing conventions
+- [.github/copilot-instructions.md](../copilot-instructions.md) - Coding guidelines
+- [docs/testing-strategy.md](../../docs/testing-strategy.md) - Testing conventions
 - The implementation in `src/` and `tests/`
 
 ## Review Checklist

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -58,8 +58,8 @@ Before starting, familiarize yourself with:
 - The Architecture document in `docs/features/<feature-name>/architecture.md`
 - The Tasks document in `docs/features/<feature-name>/tasks.md`
 - The Test Plan in `docs/features/<feature-name>/test-plan.md`
-- [docs/spec.md](docs/spec.md) - Project specification
-- [.github/copilot-instructions.md](.github/copilot-instructions.md) - Coding guidelines
+- [docs/spec.md](../../docs/spec.md) - Project specification
+- [.github/copilot-instructions.md](../copilot-instructions.md) - Coding guidelines
 - Existing source code in `src/` and tests in `tests/`
 
 ## Coding Guidelines

--- a/.github/agents/documentation-author.agent.md
+++ b/.github/agents/documentation-author.agent.md
@@ -48,10 +48,10 @@ Before starting, familiarize yourself with:
 - The Feature Specification in `docs/features/<feature-name>/specification.md`
 - The Tasks document in `docs/features/<feature-name>/tasks.md`
 - The implementation in `src/` (focus on public interfaces and user-facing behavior)
-- [README.md](README.md) - Main project documentation
-- [docs/spec.md](docs/spec.md) - Project specification
-- [docs/features.md](docs/features.md) - Feature descriptions
-- [docs/agents.md](docs/agents.md) - Workflow overview and artifact formats
+- [README.md](../../README.md) - Main project documentation
+- [docs/spec.md](../../docs/spec.md) - Project specification
+- [docs/features.md](../../docs/features.md) - Feature descriptions
+- [docs/agents.md](../../docs/agents.md) - Workflow overview and artifact formats
 - Existing documentation in `docs/`
 
 ## Documentation Standards

--- a/.github/agents/product-owner.agent.md
+++ b/.github/agents/product-owner.agent.md
@@ -49,8 +49,8 @@ Break down the feature into clear, prioritized work items with well-defined acce
 Before starting, familiarize yourself with:
 - The Feature Specification in `docs/features/<feature-name>/specification.md`
 - The Architecture document in `docs/features/<feature-name>/architecture.md` (if exists)
-- [docs/agents.md](docs/agents.md) - Workflow overview and artifact formats
-- [docs/spec.md](docs/spec.md) - Project goals and constraints
+- [docs/agents.md](../../docs/agents.md) - Workflow overview and artifact formats
+- [docs/spec.md](../../docs/spec.md) - Project goals and constraints
 
 ## Conversation Approach
 

--- a/.github/agents/quality-engineer.agent.md
+++ b/.github/agents/quality-engineer.agent.md
@@ -47,8 +47,8 @@ Before starting, familiarize yourself with:
 - The Feature Specification in `docs/features/<feature-name>/specification.md`
 - The Architecture document in `docs/features/<feature-name>/architecture.md` (if exists)
 - The Tasks document in `docs/features/<feature-name>/tasks.md`
-- [docs/testing-strategy.md](docs/testing-strategy.md) - Project testing conventions and infrastructure
-- [docs/agents.md](docs/agents.md) - Workflow overview and artifact formats
+- [docs/testing-strategy.md](../../docs/testing-strategy.md) - Project testing conventions and infrastructure
+- [docs/agents.md](../../docs/agents.md) - Workflow overview and artifact formats
 - Existing tests in `tests/` to understand patterns and conventions
 
 ## Project Testing Conventions

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -51,8 +51,8 @@ Ensure the feature is ready for release, create the release branch or tag, and v
 Before starting, familiarize yourself with:
 - The Feature Specification in `docs/features/<feature-name>/specification.md`
 - The Code Review Report in `docs/features/<feature-name>/code-review.md`
-- [docs/spec.md](docs/spec.md) - Project specification
-- [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution and release guidelines
+- [docs/spec.md](../../docs/spec.md) - Project specification
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) - Contribution and release guidelines
 - Current version in `Directory.Build.props`
 
 ## Release Process
@@ -67,7 +67,7 @@ This project uses:
 - Do NOT edit `CHANGELOG.md` manually - Versionize generates it automatically
 - Version bumping is handled by Versionize based on conventional commits
 - The CI pipeline builds and publishes the Docker image
-- **CRITICAL**: For instructions on how to use the GitHub CLI (`gh`) in automated agents, refer to the [.github/gh-cli-instructions.md](.github/gh-cli-instructions.md) file. Always use `PAGER=cat` prefix or export `GH_PAGER=cat` to prevent interactive pagers from blocking execution
+- **CRITICAL**: For instructions on how to use the GitHub CLI (`gh`) in automated agents, refer to the [.github/gh-cli-instructions.md](../gh-cli-instructions.md) file. Always use `PAGER=cat` prefix or export `GH_PAGER=cat` to prevent interactive pagers from blocking execution
 
 ## Pre-Release Checklist
 

--- a/.github/agents/requirements-engineer.agent.md
+++ b/.github/agents/requirements-engineer.agent.md
@@ -64,10 +64,10 @@ Transform an initial feature idea into a clear, unambiguous Feature Specificatio
 ## Context to Read
 
 Before starting, familiarize yourself with:
-- [docs/spec.md](docs/spec.md) - Project specification and goals
-- [docs/features.md](docs/features.md) and feature descriptions in `docs/features/` - Existing features
-- [docs/agents.md](docs/agents.md) - Workflow overview and artifact formats
-- [README.md](README.md) - Project overview
+- [docs/spec.md](../../docs/spec.md) - Project specification and goals
+- [docs/features.md](../../docs/features.md) and feature descriptions in `docs/features/` - Existing features
+- [docs/agents.md](../../docs/agents.md) - Workflow overview and artifact formats
+- [README.md](../../README.md) - Project overview
 
 ## Conversation Approach
 

--- a/.github/agents/support-engineer.agent.md
+++ b/.github/agents/support-engineer.agent.md
@@ -61,9 +61,9 @@ Gather diagnostic information, perform initial analysis, and document the proble
 ## Context to Read
 
 Before investigating, review relevant context:
-- [docs/spec.md](docs/spec.md) - Project specification
-- [docs/architecture.md](docs/architecture.md) - Architecture overview
-- [README.md](README.md) - Project overview and usage
+- [docs/spec.md](../../docs/spec.md) - Project specification
+- [docs/architecture.md](../../docs/architecture.md) - Architecture overview
+- [README.md](../../README.md) - Project overview and usage
 - Recent commits: `git log --oneline -10`
 - CI/CD workflow files in `.github/workflows/`
 
@@ -110,7 +110,7 @@ dotnet test --verbosity normal
 # Use the 'problems' tool to see diagnostics
 ```
 
-**Important:** For instructions on how to use the GitHub CLI (`gh`) in automated agents, refer to the [.github/gh-cli-instructions.md](.github/gh-cli-instructions.md) file. Always use `PAGER=cat` prefix to prevent interactive pagers from blocking execution.
+**Important:** For instructions on how to use the GitHub CLI (`gh`) in automated agents, refer to the [.github/gh-cli-instructions.md](../gh-cli-instructions.md) file. Always use `PAGER=cat` prefix to prevent interactive pagers from blocking execution.
 
 ### Step 3: Analyze the Issue
 
@@ -180,7 +180,7 @@ What actually happens (include error messages).
 ## Root Cause Analysis
 
 ### Affected Components
-- File: [path/to/file.ext](path/to/file.ext#L123)
+- File: `path/to/file.ext#L123`
 - Component: Description
 
 ### What's Broken

--- a/.github/agents/workflow-engineer.agent.md
+++ b/.github/agents/workflow-engineer.agent.md
@@ -44,19 +44,19 @@ Evolve and optimize the agent workflow by creating new agents, modifying existin
 ## Context to Read
 
 Before making changes, familiarize yourself with:
-- [docs/agents.md](docs/agents.md) - The complete workflow documentation (your primary reference)
-- [docs/ai-model-reference.md](docs/ai-model-reference.md) - **Model performance benchmarks, availability, and pricing data**
-- [.github/copilot-instructions.md](.github/copilot-instructions.md) - Project-wide Copilot instructions including tool naming conventions
+- [docs/agents.md](../../docs/agents.md) - The complete workflow documentation (your primary reference)
+- [docs/ai-model-reference.md](../../docs/ai-model-reference.md) - **Model performance benchmarks, availability, and pricing data**
+- [.github/copilot-instructions.md](../copilot-instructions.md) - Project-wide Copilot instructions including tool naming conventions
 - All existing agents in `.github/agents/*.agent.md` - Current agent definitions
-- [docs/spec.md](docs/spec.md) - Project specification
+- [docs/spec.md](../../docs/spec.md) - Project specification
 
 ## Reference Documentation
 
 When designing or modifying agents, consult these authoritative sources:
 Internal References (Priority Order)
-1. **[docs/ai-model-reference.md](docs/ai-model-reference.md)** - ⭐ Model benchmarks, availability, pricing (check first)
-2. **[docs/agents.md](docs/agents.md)** - Workflow documentation and agent responsibilities
-3. **[.github/copilot-instructions.md](.github/copilot-instructions.md)** - Tool naming conventions, coding standards
+1. **[docs/ai-model-reference.md](../../docs/ai-model-reference.md)** - ⭐ Model benchmarks, availability, pricing (check first)
+2. **[docs/agents.md](../../docs/agents.md)** - Workflow documentation and agent responsibilities
+3. **[.github/copilot-instructions.md](../copilot-instructions.md)** - Tool naming conventions, coding standards
 
 ### VS Code Copilot Documentation
 - [Custom Agents Overview](https://code.visualstudio.com/docs/copilot/customization/custom-agents) - How to create and configure custom agents
@@ -78,7 +78,7 @@ When creating or modifying agents, choose the appropriate language model based o
 
 ### Reference Data
 
-**Always consult [docs/ai-model-reference.md](docs/ai-model-reference.md)** for:
+**Always consult [docs/ai-model-reference.md](../../docs/ai-model-reference.md)** for:
 - Current performance benchmarks by category (Coding, Reasoning, Language, Instruction Following, etc.)
 - Model availability in GitHub Copilot Pro
 - Premium request multipliers (cost)
@@ -264,7 +264,7 @@ Ask clarifying questions one at a time if the goal is unclear:
 Review current state and gather best practices:
 - Read all affected agent files in `.github/agents/`
 - Check workflow documentation in `docs/agents.md`
-- Consult [docs/ai-model-reference.md](docs/ai-model-reference.md) for model data (if selecting/changing models)
+- Consult [docs/ai-model-reference.md](../../docs/ai-model-reference.md) for model data (if selecting/changing models)
 - Review handoff relationships between agents
 - Consult [VS Code Copilot docs](https://code.visualstudio.com/docs/copilot/customization/custom-agents) for tool reference
 
@@ -350,7 +350,7 @@ When updating `docs/agents.md`, verify all of these:
 2. **CRITICAL**: Check current branch with `git branch --show-current` - if on main, create feature branch FIRST
 2. Identify specific problem or gap
 3. Read current agent definition completely
-4. Consult [docs/ai-model-reference.md](docs/ai-model-reference.md) if model change considered
+4. Consult [docs/ai-model-reference.md](../../docs/ai-model-reference.md) if model change considered
 5. Propose targeted improvement with data/rationale
 6. Test change doesn't break handoffs
 7. Update documentation if role/handoffs change
@@ -362,7 +362,7 @@ When updating `docs/agents.md`, verify all of these:
 ### Improving Existing Agent
 1. Identify specific problem or gap
 2. Read current agent definition completely
-3. Consult [docs/ai-model-reference.md](docs/ai-model-reference.md) if model change considered
+3. Consult [docs/ai-model-reference.md](../../docs/ai-model-reference.md) if model change considered
 4. Propose targeted improvement with data/rationale
 5. Test change doesn't break handoffs
 6. Update documentation if role/handoffs change
@@ -405,7 +405,7 @@ When updating `docs/agents.md`, verify all of these:
 **Key principle**: Never commit workflow fixes and feature work together. They have different scopes and should be in separate PRs.
 
 ### Reviewing All Agents (Periodic Maintenance)
-1. Check [docs/ai-model-reference.md](docs/ai-model-reference.md) update date
+1. Check [docs/ai-model-reference.md](../../docs/ai-model-reference.md) update date
 2. If >1 month old, recommend updating it first
 3. Review each agent's model against current benchmarks
 4. Verify all tool names are valid (check recent VS Code updates)
@@ -416,7 +416,7 @@ When updating `docs/agents.md`, verify all of these:
 ### Updating Model Reference Data
 1. Fetch latest [LiveBench benchmarks](https://livebench.ai/)
 2. Check [GitHub Copilot Supported Models](https://docs.github.com/en/copilot/reference/ai-models/supported-models)
-3. Update [docs/ai-model-reference.md](docs/ai-model-reference.md):
+3. Update [docs/ai-model-reference.md](../../docs/ai-model-reference.md):
    - Model availability table
    - Category-specific performance tables
    - Premium multipliers


### PR DESCRIPTION
## Summary

This PR updates all agent tool definitions and fixes relative path links in agent files.

## Changes

### Tool Naming Convention Updates
- Updated all tool names to use VS Code Copilot's prefixed format:
  - `read/` prefix: readFile, problems, terminalLastCommand
  - `search/` prefix: listDirectory, codebase, usages, changes
  - `edit/` prefix: createFile, editFiles
  - `execute/` prefix: runInTerminal, getTerminalOutput, runTests
  - `web/` prefix: fetch, githubRepo

### Added MCP Server Tools
Based on the project's MCP configuration:

| Agent | `microsoft-learn/*` | `terraform-mcp-server/*` |
|-------|:---:|:---:|
| Developer | ✅ | ✅ |
| Code Reviewer | ✅ | ✅ |
| Support Engineer | ✅ | ✅ |
| Requirements Engineer | ❌ | ✅ |
| Architect | ✅ | ❌ |
| Documentation Author | ✅ | ❌ |
| Quality Engineer | ✅ | ❌ |
| Workflow Engineer | ✅ | ❌ |
| Product Owner | ❌ | ❌ |
| Release Manager | ❌ | ❌ |

### Fixed Relative Paths
Links in agent files must be relative to the agent file location (`.github/agents/`):
- `docs/` → `../../docs/`
- `.github/` → `../`
- `README.md` → `../../README.md`
- `CONTRIBUTING.md` → `../../CONTRIBUTING.md`

### Documentation
- Updated Tool Selection Guide in Workflow Engineer agent with all 5 available MCP servers

## Notes
The `microsoft-learn/*` tool warnings in VS Code Problems panel are informational hints (severity 4). MCP server tools can't be validated at design time - they work correctly at runtime when the MCP server is connected.