### PR TITLE
feat: add Scriban reference and comprehensive demo requirements to agents

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -56,6 +56,7 @@ Before starting, familiarize yourself with:
 - The Test Plan in `docs/features/<feature-name>/test-plan.md`
 - [.github/copilot-instructions.md](../copilot-instructions.md) - Coding guidelines
 - [docs/testing-strategy.md](../../docs/testing-strategy.md) - Testing conventions
+- [Scriban Language Reference](https://github.com/scriban/scriban/blob/master/doc/language.md) - For template-related work
 - The implementation in `src/` and `tests/`
 
 ## Review Checklist
@@ -90,6 +91,7 @@ Before starting, familiarize yourself with:
 - [ ] Documentation is updated to reflect changes
 - [ ] No contradictions in documentation
 - [ ] CHANGELOG.md was NOT modified (auto-generated)
+- [ ] Comprehensive demo updated if feature has visible markdown impact
 
 ## Review Approach
 

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -35,6 +35,7 @@ Produce clean, well-tested code that meets all acceptance criteria and follows p
 - Keep files under 300 lines, refactor if larger
 - Check for existing code to reuse before creating new code
 - Use `_camelCase` for private fields
+- Update `examples/comprehensive-demo/plan.json` when features have visible impact on generated markdown
 
 ### ⚠️ Ask First
 - Changes that affect architecture decisions
@@ -60,6 +61,7 @@ Before starting, familiarize yourself with:
 - The Test Plan in `docs/features/<feature-name>/test-plan.md`
 - [docs/spec.md](../../docs/spec.md) - Project specification
 - [.github/copilot-instructions.md](../copilot-instructions.md) - Coding guidelines
+- [Scriban Language Reference](https://github.com/scriban/scriban/blob/master/doc/language.md) - For template-related work
 - Existing source code in `src/` and tests in `tests/`
 
 ## Coding Guidelines


### PR DESCRIPTION
## Summary

Improves agent effectiveness by adding essential references and requirements for template-related work and demo maintenance.

## Changes

- **Developer agent**: Added Scriban language reference to Context section and requirement to update comprehensive demo when features have visible markdown impact
- **Code Reviewer agent**: Added Scriban language reference to Context section and checklist item for comprehensive demo verification

## Rationale

1. **Scriban Reference**: Agents working with templates (Developer, Code Reviewer) need access to the Scriban language documentation to effectively implement and review template-related features
2. **Comprehensive Demo Requirement**: The comprehensive demo is meant to showcase all features. Making it explicit that developers must update it ensures it stays current as features evolve

## Impact

- Agents have access to essential template syntax documentation
- Demo will stay up-to-date with feature evolution
- No breaking changes, pure workflow improvement