### PR TITLE
workflow: skip CI and releases for workflow-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '.github/agents/**'
+      - 'docs/agents.md'
+      - 'docs/ai-model-reference.md'
 
 permissions:
   contents: write

--- a/.versionize
+++ b/.versionize
@@ -36,6 +36,11 @@
         "type": "chore",
         "section": "🔧 Maintenance",
         "hidden": true
+      },
+      {
+        "type": "workflow",
+        "section": "🔧 Workflow",
+        "hidden": true
       }
     ],
     "linkTemplates": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ Use these branch prefixes:
 - `docs/` — Documentation changes
 - `refactor/` — Code refactoring
 - `chore/` — Maintenance tasks
+- `workflow/` — Agent/workflow changes (`.github/agents/`, workflow documentation)
 
 ## Commit Messages
 
@@ -52,6 +53,7 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) t
 | `build` | Build system or dependency changes | None |
 | `ci` | CI configuration changes | None |
 | `chore` | Other maintenance tasks | None |
+| `workflow` | Agent/workflow changes (`.github/agents/`, `docs/agents.md`) | None |
 | `revert` | Reverting a previous commit | Depends |
 
 ### Breaking Changes
@@ -83,6 +85,9 @@ git commit -m "fix(parser): handle empty resource changes array"
 
 # Documentation
 git commit -m "docs: update installation instructions"
+
+# Workflow changes
+git commit -m "workflow: update Product Owner agent model"
 
 # Breaking change
 git commit -m "feat(api)!: rename TerraformPlan to PlanResult"


### PR DESCRIPTION
## Changes

This PR implements rules to prevent workflow-related changes from triggering CI builds and version releases.

### What Changed

1. **CI Workflow** ()
   - Added  filter to skip CI when only these files change:
     - 
     - 
     - 

2. **Versionize Config** ()
   - Added `workflow:` commit type with `hidden: true`
   - Workflow commits will not appear in CHANGELOG.md or trigger version bumps

3. **Documentation** ()
   - Added `workflow/` branch naming convention
   - Added `workflow:` commit type to the table
   - Added example workflow commit message

### Why

- Workflow and agent improvements are meta-level changes that don't affect the tool's functionality
- These changes should not trigger new releases or appear in user-facing changelogs
- Reduces noise in the release process and keeps changelogs focused on features/fixes

### Testing

After merging, pushes to main from `workflow/*` branches will:
- ✅ Skip CI build and tests
- ✅ Skip Versionize (no version bump, no changelog entry)
- ✅ Not trigger a release

Regular feature/fix branches will continue to work normally.