### PR TITLE
fix(ci): remove invalid workflows permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ concurrency:
 
 permissions:
   contents: write
-  workflows: write
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- remove unsupported GITHUB_TOKEN permission 'workflows: write' that prevents the CI workflow from starting
- keep concurrency group and paths-ignore additions intact

## Testing

- Husky pre-commit hooks: dotnet-format, dotnet-build