### PR TITLE
fix: normalize NSG table descriptions for markdownlint

### DIFF
--- a/artifacts/comprehensive-demo.md
+++ b/artifacts/comprehensive-demo.md
@@ -189,8 +189,8 @@
 
 | Change | Name | Priority | Direction | Access | Protocol | Source Addresses | Source Ports | Destination Addresses | Destination Ports | Description |
 | -------- | ------ | ---------- | ----------- | -------- | ---------- | ------------------ | ------------ | ---------------------- | ------------------- | ------------- |
-| ➕ | allow-https | 100 | Inbound | Allow | Tcp | * | * | * | 443 |  |
-| ❌ | allow-http | 100 | Inbound | Allow | Tcp | * | * | * | 80 |  |
+| ➕ | allow-https | 100 | Inbound | Allow | Tcp | * | * | * | 443 | - |
+| ❌ | allow-http | 100 | Inbound | Allow | Tcp | * | * | * | 80 | - |
 
 #### ❌ module.network.azurerm_virtual_network.decom
 

--- a/src/Oocx.TfPlan2Md/MarkdownGeneration/Templates/azurerm/network_security_group.sbn
+++ b/src/Oocx.TfPlan2Md/MarkdownGeneration/Templates/azurerm/network_security_group.sbn
@@ -37,6 +37,11 @@
      {{ ret "*" }}
 {{ end }}
 
+{{ func description_or_dash(value) }}
+     {{- if value && value != "" -}}{{ ret value }}{{- end -}}
+     {{ ret "-" }}
+{{ end }}
+
 {{~ if before_json && after_json && before_json.security_rule && after_json.security_rule ~}}
 {{ diff = diff_array before_json.security_rule after_json.security_rule "name" }}
 
@@ -45,16 +50,16 @@
 | Change | Name | Priority | Direction | Access | Protocol | Source Addresses | Source Ports | Destination Addresses | Destination Ports | Description |
 | -------- | ------ | ---------- | ----------- | -------- | ---------- | ------------------ | ------------ | ---------------------- | ------------------- | ------------- |
 {{ for rule in diff.added | array.sort "priority" }}
-| ➕ | {{ rule.name | escape_markdown }} | {{ rule.priority | escape_markdown }} | {{ rule.direction | escape_markdown }} | {{ rule.access | escape_markdown }} | {{ rule.protocol | escape_markdown }} | {{ source_addresses(rule) | escape_markdown }} | {{ source_ports(rule) | escape_markdown }} | {{ destination_addresses(rule) | escape_markdown }} | {{ destination_ports(rule) | escape_markdown }} | {{ (rule.description ?? "") | escape_markdown }} |
+| ➕ | {{ rule.name | escape_markdown }} | {{ rule.priority | escape_markdown }} | {{ rule.direction | escape_markdown }} | {{ rule.access | escape_markdown }} | {{ rule.protocol | escape_markdown }} | {{ source_addresses(rule) | escape_markdown }} | {{ source_ports(rule) | escape_markdown }} | {{ destination_addresses(rule) | escape_markdown }} | {{ destination_ports(rule) | escape_markdown }} | {{ description_or_dash(rule.description) | escape_markdown }} |
 {{ end }}
 {{ for item in diff.modified | array.sort "after.priority" }}
-| 🔄 | {{ item.after.name | escape_markdown }} | {{ format_diff item.before.priority item.after.priority }} | {{ format_diff (item.before.direction ?? "") (item.after.direction ?? "") }} | {{ format_diff (item.before.access ?? "") (item.after.access ?? "") }} | {{ format_diff (item.before.protocol ?? "") (item.after.protocol ?? "") }} | {{ format_diff (source_addresses(item.before)) (source_addresses(item.after)) }} | {{ format_diff (source_ports(item.before)) (source_ports(item.after)) }} | {{ format_diff (destination_addresses(item.before)) (destination_addresses(item.after)) }} | {{ format_diff (destination_ports(item.before)) (destination_ports(item.after)) }} | {{ format_diff (item.before.description ?? "") (item.after.description ?? "") }} |
+| 🔄 | {{ item.after.name | escape_markdown }} | {{ format_diff item.before.priority item.after.priority }} | {{ format_diff (item.before.direction ?? "") (item.after.direction ?? "") }} | {{ format_diff (item.before.access ?? "") (item.after.access ?? "") }} | {{ format_diff (item.before.protocol ?? "") (item.after.protocol ?? "") }} | {{ format_diff (source_addresses(item.before)) (source_addresses(item.after)) }} | {{ format_diff (source_ports(item.before)) (source_ports(item.after)) }} | {{ format_diff (destination_addresses(item.before)) (destination_addresses(item.after)) }} | {{ format_diff (destination_ports(item.before)) (destination_ports(item.after)) }} | {{ format_diff (description_or_dash(item.before.description)) (description_or_dash(item.after.description)) }} |
 {{ end }}
 {{ for rule in diff.removed | array.sort "priority" }}
-| ❌ | {{ rule.name | escape_markdown }} | {{ rule.priority | escape_markdown }} | {{ rule.direction | escape_markdown }} | {{ rule.access | escape_markdown }} | {{ rule.protocol | escape_markdown }} | {{ source_addresses(rule) | escape_markdown }} | {{ source_ports(rule) | escape_markdown }} | {{ destination_addresses(rule) | escape_markdown }} | {{ destination_ports(rule) | escape_markdown }} | {{ (rule.description ?? "") | escape_markdown }} |
+| ❌ | {{ rule.name | escape_markdown }} | {{ rule.priority | escape_markdown }} | {{ rule.direction | escape_markdown }} | {{ rule.access | escape_markdown }} | {{ rule.protocol | escape_markdown }} | {{ source_addresses(rule) | escape_markdown }} | {{ source_ports(rule) | escape_markdown }} | {{ destination_addresses(rule) | escape_markdown }} | {{ destination_ports(rule) | escape_markdown }} | {{ description_or_dash(rule.description) | escape_markdown }} |
 {{ end }}
 {{ for rule in diff.unchanged | array.sort "priority" }}
-| ⏺️ | {{ rule.name | escape_markdown }} | {{ rule.priority | escape_markdown }} | {{ rule.direction | escape_markdown }} | {{ rule.access | escape_markdown }} | {{ rule.protocol | escape_markdown }} | {{ source_addresses(rule) | escape_markdown }} | {{ source_ports(rule) | escape_markdown }} | {{ destination_addresses(rule) | escape_markdown }} | {{ destination_ports(rule) | escape_markdown }} | {{ (rule.description ?? "") | escape_markdown }} |
+| ⏺️ | {{ rule.name | escape_markdown }} | {{ rule.priority | escape_markdown }} | {{ rule.direction | escape_markdown }} | {{ rule.access | escape_markdown }} | {{ rule.protocol | escape_markdown }} | {{ source_addresses(rule) | escape_markdown }} | {{ source_ports(rule) | escape_markdown }} | {{ destination_addresses(rule) | escape_markdown }} | {{ destination_ports(rule) | escape_markdown }} | {{ description_or_dash(rule.description) | escape_markdown }} |
 {{ end }}
 
 
@@ -64,7 +69,7 @@
 | Name | Priority | Direction | Access | Protocol | Source Addresses | Source Ports | Destination Addresses | Destination Ports | Description |
 | ------ | ---------- | ----------- | -------- | ---------- | ------------------ | ------------ | ---------------------- | ------------------- | ------------- |
 {{ for rule in after_json.security_rule | array.sort "priority" }}
-| {{ rule.name | escape_markdown }} | {{ rule.priority | escape_markdown }} | {{ rule.direction | escape_markdown }} | {{ rule.access | escape_markdown }} | {{ rule.protocol | escape_markdown }} | {{ source_addresses(rule) | escape_markdown }} | {{ source_ports(rule) | escape_markdown }} | {{ destination_addresses(rule) | escape_markdown }} | {{ destination_ports(rule) | escape_markdown }} | {{ (rule.description ?? "") | escape_markdown }} |
+| {{ rule.name | escape_markdown }} | {{ rule.priority | escape_markdown }} | {{ rule.direction | escape_markdown }} | {{ rule.access | escape_markdown }} | {{ rule.protocol | escape_markdown }} | {{ source_addresses(rule) | escape_markdown }} | {{ source_ports(rule) | escape_markdown }} | {{ destination_addresses(rule) | escape_markdown }} | {{ destination_ports(rule) | escape_markdown }} | {{ description_or_dash(rule.description) | escape_markdown }} |
 {{ end }}
 
 {{~ else if action == "delete" && before_json && before_json.security_rule ~}}
@@ -73,7 +78,7 @@
 | Name | Priority | Direction | Access | Protocol | Source Addresses | Source Ports | Destination Addresses | Destination Ports | Description |
 | ------ | ---------- | ----------- | -------- | ---------- | ------------------ | ------------ | ---------------------- | ------------------- | ------------- |
 {{ for rule in before_json.security_rule | array.sort "priority" }}
-| {{ rule.name | escape_markdown }} | {{ rule.priority | escape_markdown }} | {{ rule.direction | escape_markdown }} | {{ rule.access | escape_markdown }} | {{ rule.protocol | escape_markdown }} | {{ source_addresses(rule) | escape_markdown }} | {{ source_ports(rule) | escape_markdown }} | {{ destination_addresses(rule) | escape_markdown }} | {{ destination_ports(rule) | escape_markdown }} | {{ (rule.description ?? "") | escape_markdown }} |
+| {{ rule.name | escape_markdown }} | {{ rule.priority | escape_markdown }} | {{ rule.direction | escape_markdown }} | {{ rule.access | escape_markdown }} | {{ rule.protocol | escape_markdown }} | {{ source_addresses(rule) | escape_markdown }} | {{ source_ports(rule) | escape_markdown }} | {{ destination_addresses(rule) | escape_markdown }} | {{ destination_ports(rule) | escape_markdown }} | {{ description_or_dash(rule.description) | escape_markdown }} |
 {{ end }}
 
 {{~ else ~}}

--- a/tests/Oocx.TfPlan2Md.Tests/TestData/Snapshots/comprehensive-demo.md
+++ b/tests/Oocx.TfPlan2Md.Tests/TestData/Snapshots/comprehensive-demo.md
@@ -189,8 +189,8 @@
 
 | Change | Name | Priority | Direction | Access | Protocol | Source Addresses | Source Ports | Destination Addresses | Destination Ports | Description |
 | -------- | ------ | ---------- | ----------- | -------- | ---------- | ------------------ | ------------ | ---------------------- | ------------------- | ------------- |
-| ➕ | allow-https | 100 | Inbound | Allow | Tcp | * | * | * | 443 |  |
-| ❌ | allow-http | 100 | Inbound | Allow | Tcp | * | * | * | 80 |  |
+| ➕ | allow-https | 100 | Inbound | Allow | Tcp | * | * | * | 443 | - |
+| ❌ | allow-http | 100 | Inbound | Allow | Tcp | * | * | * | 80 | - |
 
 #### ❌ module.network.azurerm_virtual_network.decom
 


### PR DESCRIPTION
## Summary
- default empty NSG rule descriptions to '-' to satisfy markdownlint MD060 compact style
- regenerate comprehensive demo output
- update snapshot to reflect new placeholder

All tests pass and markdownlint is clean.