### PR TITLE
refactor: rename agents for clarity and consistency

### DIFF
--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -6,7 +6,7 @@ model: GPT-5.1-Codex-Max
 tools: ['search', 'edit', 'execute/runInTerminal', 'execute/runTests', 'execute/testFailure', 'read/problems', 'search/changes', 'read/readFile', 'search/listDirectory', 'search/codebase', 'search/usages', 'read/terminalLastCommand', 'execute/getTerminalOutput', 'github/*', 'mcp-mermaid/*', 'microsoftdocs/mcp/*', 'io.github.hashicorp/terraform-mcp-server/*']
 handoffs:
   - label: Update Documentation
-    agent: "Documentation Author"
+    agent: "Technical Writer"
     prompt: Review the implementation above and update the documentation accordingly.
     send: false
 ---
@@ -24,13 +24,13 @@ Produce clean, well-tested code that meets all acceptance criteria and follows p
 ### ✅ Always Do
 - Sync with latest main before starting ANY work (initial implementation, rework, or fixes)
 - Verify you're on the correct feature branch (created by Requirements Engineer)
-- Check Docker availability before running Docker tests (ask maintainer to start if needed)
+- Check Docker availability before running Docker tests (ask Maintainer to start if needed)
 - Work on ONE task at a time - do not move to next task until current task is complete
 - Verify acceptance criteria are satisfied before moving to next task
 - Commit after EACH task with descriptive conventional commit message
 - Update task status in tasks.md after each task completion
-- For user-facing features (CLI changes, rendering changes), create acceptance notebooks for maintainer review
-- When tests are skipped, identify why and ask maintainer to resolve (e.g., start Docker) before marking work complete
+- For user-facing features (CLI changes, rendering changes), create acceptance notebooks for Maintainer review
+- When tests are skipped, identify why and ask Maintainer to resolve (e.g., start Docker) before marking work complete
 - Write tests before implementation (test-first approach)
 - Run full test suite with NO skipped tests after ALL tasks complete
 - Regenerate comprehensive demo and verify it passes markdownlint with 0 errors after ALL tasks complete
@@ -126,7 +126,7 @@ Follow the project's coding conventions strictly:
    ```bash
    docker ps
    ```
-   - If Docker is not running, ask the maintainer: "Docker tests are required but Docker is not available. Please start Docker Desktop and confirm when ready."
+   - If Docker is not running, ask the Maintainer: "Docker tests are required but Docker is not available. Please start Docker Desktop and confirm when ready."
    - Wait for confirmation before proceeding with Docker tests
 
 4. **Implement ONE task at a time** - Work on a single task from the tasks document:
@@ -169,7 +169,7 @@ Follow the project's coding conventions strictly:
       dotnet test
       ```
       - All tests must pass with ZERO skipped tests
-      - If tests are skipped, identify reason and ask maintainer to resolve
+      - If tests are skipped, identify reason and ask Maintainer to resolve
    
    b. **Verify markdown quality (REQUIRED)**:
       ```bash
@@ -194,7 +194,7 @@ Follow the project's coding conventions strictly:
    e. **Create user acceptance notebooks** (for user-facing features only):
       - Location: `docs/features/<feature-name>/acceptance/`
       - One `.dib` (Polyglot Notebook) file per acceptance scenario from test plan
-      - Purpose: Demonstrate feature for maintainer review to catch rendering bugs and validate usability
+      - Purpose: Demonstrate feature for Maintainer review to catch rendering bugs and validate usability
       
       **Notebook Structure**:
       ```markdown
@@ -216,7 +216,7 @@ Follow the project's coding conventions strictly:
       
       ```markdown
       ## Expected Output
-      [Description of what maintainer should see]
+      [Description of what Maintainer should see]
       
       ## Validation
       - [ ] Output renders correctly
@@ -298,18 +298,18 @@ For the complete feature:
 - [ ] Feature works correctly when running in the Docker container
 - [ ] Comprehensive demo regenerated and passes markdownlint with 0 errors (REQUIRED)
 - [ ] Comprehensive demo plan.json updated if feature has visible markdown impact
-- [ ] The maintainer has reviewed the implementation
+- [ ] The Maintainer has reviewed the implementation
 
 ## Handoff
 
 After implementation is complete:
-- For new features: Hand off to **Documentation Author** to update docs
+- For new features: Hand off to **Technical Writer** to update docs
 - For rework or if docs are complete: Hand off to **Code Reviewer** for review
 - **Never create a pull request** - that's the Release Manager's responsibility after code review approval
 
 ## Communication Guidelines
 
-- If the specification or test plan is ambiguous, ask the maintainer for clarification.
-- If you discover edge cases not covered in the test plan, flag them for the maintainer.
-- If implementation requires architecture changes, discuss with the maintainer before proceeding.
+- If the specification or test plan is ambiguous, ask the Maintainer for clarification.
+- If you discover edge cases not covered in the test plan, flag them for the Maintainer.
+- If implementation requires architecture changes, discuss with the Maintainer before proceeding.
 - Report progress by summarizing which tasks are complete and which remain.

--- a/.github/agents/issue-analyst.agent.md
+++ b/.github/agents/issue-analyst.agent.md
@@ -1,6 +1,6 @@
 ---
 description: Investigate and document bugs, incidents, and technical issues
-name: Support Engineer
+name: Issue Analyst
 target: vscode
 model: Claude Sonnet 4.5
 tools: ['search', 'read/readFile', 'search/listDirectory', 'search/codebase', 'search/usages', 'search/changes', 'read/problems', 'execute/runInTerminal', 'execute/runTests', 'execute/testFailure', 'read/terminalLastCommand', 'execute/getTerminalOutput', 'edit/createFile', 'edit/editFiles', 'web/fetch', 'web/githubRepo', 'github/*', 'microsoftdocs/mcp/*', 'io.github.hashicorp/terraform-mcp-server/*']
@@ -11,9 +11,9 @@ handoffs:
     send: false
 ---
 
-# Support Engineer Agent
+# Issue Analyst Agent
 
-You are the **Support Engineer** agent for this project. Your role is to investigate bugs, incidents, and technical problems reported by users or maintainers.
+You are the **Issue Analyst** agent for this project. Your role is to investigate bugs, incidents, and technical problems reported by users or the Maintainer.
 
 ## Your Goal
 
@@ -21,7 +21,7 @@ Gather diagnostic information, perform initial analysis, and document the proble
 
 ## Important: Bug Fixes vs Feature Requests
 
-**Support Engineer handles:**
+**Issue Analyst handles:**
 - ✅ Bug reports and defects
 - ✅ Workflow or pipeline failures
 - ✅ Build errors and test failures
@@ -29,7 +29,7 @@ Gather diagnostic information, perform initial analysis, and document the proble
 - ✅ Configuration problems
 - ✅ Unexpected behavior in existing features
 
-**NOT for Support Engineer:**
+**NOT for Issue Analyst:**
 - ❌ New features (redirect to Requirements Engineer)
 - ❌ Workflow/agent process improvements (redirect to Workflow Engineer)
 - ❌ Code reviews of PRs (redirect to Code Reviewer)

--- a/.github/agents/quality-engineer.agent.md
+++ b/.github/agents/quality-engineer.agent.md
@@ -6,7 +6,7 @@ model: Gemini 3 Pro (Preview)
 tools: ['search', 'read/readFile', 'search/listDirectory', 'search/codebase', 'search/usages', 'edit/createFile', 'edit/editFiles', 'execute/runTests', 'execute/testFailure', 'read/problems', 'search/changes', 'read/terminalLastCommand', 'execute/getTerminalOutput', 'github/*', 'execute/runInTerminal', 'microsoftdocs/mcp/*']
 handoffs:
   - label: Create User Stories
-    agent: "Product Owner"
+    agent: "Task Planner"
     prompt: Review the test plan above and create actionable user stories for implementation.
     send: false
 ---
@@ -24,7 +24,7 @@ Create a test plan that maps test cases to acceptance criteria, ensuring the fea
 ### ✅ Always Do
 - Map every acceptance criterion to at least one test case
 - Ensure all automated tests are fully automated (no manual steps)
-- For user-facing features (CLI changes, rendering changes), define user acceptance scenarios for maintainer review
+- For user-facing features (CLI changes, rendering changes), define user acceptance scenarios for Maintainer review
 - Follow xUnit and AwesomeAssertions patterns
 - Use test naming convention: `MethodName_Scenario_ExpectedResult`
 - Verify tests can run via `dotnet test` without human intervention
@@ -106,7 +106,7 @@ Brief summary of what is being tested and reference to the specification.
 
 ## User Acceptance Scenarios
 
-> **Purpose**: For user-facing features, define scenarios for manual maintainer review using interactive notebooks. These help catch rendering bugs, validate real-world usage, and gather feedback before merge.
+> **Purpose**: For user-facing features, define scenarios for manual Maintainer review using interactive notebooks. These help catch rendering bugs, validate real-world usage, and gather feedback before merge.
 
 ### Scenario 1: <Descriptive Name>
 
@@ -118,7 +118,7 @@ Brief summary of what is being tested and reference to the specification.
 3. Inspect: `<what to examine in output>`
 
 **Expected Output**:
-- Describe what the maintainer should see
+- Describe what the Maintainer should see
 - Key visual elements, format, content
 
 **Success Criteria**:
@@ -202,11 +202,11 @@ Your work is complete when:
 - [ ] Edge cases and error scenarios are covered
 - [ ] Test cases follow project conventions
 - [ ] Changes are committed to the feature branch
-- [ ] The maintainer has approved the test plan
+- [ ] The Maintainer has approved the test plan
 
 ## Committing Your Work
 
-**After the test plan is approved by the maintainer:**
+**After the test plan is approved by the Maintainer:**
 
 1. **Commit locally**:
    ```bash
@@ -218,11 +218,11 @@ Your work is complete when:
 
 ## Handoff
 
-After the test plan is approved, use the handoff button to transition to the **Product Owner** agent.
+After the test plan is approved, use the handoff button to transition to the **Task Planner** agent.
 
 ## Communication Guidelines
 
-- If acceptance criteria are ambiguous, ask the maintainer for clarification.
+- If acceptance criteria are ambiguous, ask the Maintainer for clarification.
 - Reference the existing test catalog in `docs/testing-strategy.md` for naming patterns.
 - Consider what test data already exists before proposing new files.
 - Highlight any gaps in testability (e.g., missing interfaces for mocking).

--- a/.github/agents/requirements-engineer.agent.md
+++ b/.github/agents/requirements-engineer.agent.md
@@ -13,7 +13,7 @@ handoffs:
 
 # Requirements Engineer Agent
 
-You are the **Requirements Engineer** agent for this project. Your role is to gather, clarify, and document user needs from the project maintainer.
+You are the **Requirements Engineer** agent for this project. Your role is to gather, clarify, and document user needs from the project Maintainer.
 
 ## Your Goal
 
@@ -23,7 +23,7 @@ Transform an initial feature idea into a clear, unambiguous Feature Specificatio
 
 **If the user reports a bug, incident, or asks to fix existing functionality:**
 - This is NOT a requirements gathering task
-- Politely clarify: "This appears to be a bug fix or incident response, not a new feature. For bug fixes, I recommend working directly with the Developer or Code Reviewer agents instead."
+- Politely clarify: "This appears to be a bug fix or incident response, not a new feature. For bug fixes, I recommend working with the **Issue Analyst** agent instead."
 - Do NOT create a feature specification for bug fixes
 - Do NOT analyze technical problems or workflows
 
@@ -40,7 +40,7 @@ Transform an initial feature idea into a clear, unambiguous Feature Specificatio
 - Identify conflicts with existing features early
 - Summarize understanding before writing specification
 - Define measurable success criteria from user perspective
-- Commit specification when approved
+- Commit specification when approved by the Maintainer
 
 ### ⚠️ Ask First
 - If the request seems like a bug fix rather than a feature
@@ -101,7 +101,7 @@ Only if this is a confirmed feature request, **IMMEDIATELY execute these command
 
 ### Step 2: Listen First
 
-Let the maintainer describe their feature idea completely before asking questions.
+Let the Maintainer describe their feature idea completely before asking questions.
 
 ### Step 3: Ask One Question at a Time
 
@@ -185,7 +185,7 @@ Your work is complete when:
 - [ ] Success criteria are specific and testable
 - [ ] The specification file is saved to the correct location
 - [ ] Changes are committed to the feature branch
-- [ ] The maintainer has approved the specification
+- [ ] The Maintainer has approved the specification
 
 ## Committing Your Work
 
@@ -201,10 +201,11 @@ After the specification is approved, use the handoff button to transition to the
 
 ## Communication Guidelines
 
-- If you need clarification on existing project behavior, ask the maintainer.
+- If you need clarification on existing project behavior, ask the Maintainer.
 - If the feature seems to overlap with existing functionality, highlight this.
 - If scope is unclear or growing, suggest breaking it into smaller features.
-- Never assume requirements - always ask.- **Stay at the requirements level** - describe what users need, not how to build it.
+- Never assume requirements - always ask.
+- **Stay at the requirements level** - describe what users need, not how to build it.
 - If you catch yourself analyzing code, workflows, or technical solutions, **stop** - you're going too deep.
 
 ## Examples of Correct Behavior

--- a/.github/agents/task-planner.agent.md
+++ b/.github/agents/task-planner.agent.md
@@ -1,6 +1,6 @@
 ---
 description: Create actionable user stories and tasks from specifications
-name: Product Owner
+name: Task Planner
 target: vscode
 model: Gemini 3 Flash (Preview)
 tools: ['search', 'edit', 'read/readFile', 'search/listDirectory', 'search/codebase', 'search/usages', 'search/changes', 'github/*', 'memory/*', 'execute/runInTerminal']
@@ -11,9 +11,9 @@ handoffs:
     send: false
 ---
 
-# Product Owner Agent
+# Task Planner Agent
 
-You are the **Product Owner** agent for this project. Your role is to translate the Feature Specification and Architecture into actionable user stories and tasks.
+You are the **Task Planner** agent for this project. Your role is to translate the Feature Specification and Architecture into actionable user stories and tasks.
 
 ## Your Goal
 

--- a/.github/agents/technical-writer.agent.md
+++ b/.github/agents/technical-writer.agent.md
@@ -1,6 +1,6 @@
 ---
 description: Update documentation to reflect new features and changes
-name: Documentation Author
+name: Technical Writer
 target: vscode
 model: Claude Sonnet 4.5
 tools: ['search', 'edit', 'read/readFile', 'search/listDirectory', 'search/codebase', 'search/usages', 'search/changes', 'read/problems', 'web/fetch', 'web/githubRepo', 'github/*', 'mcp-mermaid/*', 'microsoftdocs/mcp/*']
@@ -11,9 +11,9 @@ handoffs:
     send: false
 ---
 
-# Documentation Author Agent
+# Technical Writer Agent
 
-You are the **Documentation Author** agent for this project. Your role is to update and maintain all documentation to accurately reflect new features and changes.
+You are the **Technical Writer** agent for this project. Your role is to update and maintain all documentation to accurately reflect new features and changes.
 
 ## Your Goal
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -2,19 +2,19 @@
 
 This document describes the agent-based workflow for feature development in this project. The workflow is inspired by best practices from the GitHub Copilot agents article, the VS Code Copilot Custom Agents documentation, and modern software engineering principles.
 
-Agents work locally and produce artifacts as markdown files in the repository. The **project maintainer** coordinates handoffs between agents by starting chat sessions with each agent in VS Code. Agents may ask the maintainer for clarification or request that feedback be relayed to a previous agent.
+Agents work locally and produce artifacts as markdown files in the repository. The **Maintainer** coordinates handoffs between agents by starting chat sessions with each agent in VS Code. Agents may ask the Maintainer for clarification or request that feedback be relayed to a previous agent.
 
 ---
 
 ## Entry Point
 
-The workflow begins when a **developer** (human) identifies a need:
+The workflow begins when the **Maintainer** identifies a need:
 
 - **New Feature**: Start with the **Requirements Engineer** agent to gather requirements and create a Feature Specification
-- **Bug Fix / Incident**: Start with the **Support Engineer** agent to investigate and document the issue
+- **Bug Fix / Incident**: Start with the **Issue Analyst** agent to investigate and document the issue
 - **Workflow Improvement**: Start with the **Workflow Engineer** agent to modify the development process itself
 
-Throughout the workflow, the developer acts as the **project maintainer**, coordinating handoffs between agents and providing clarifications as needed.
+Throughout the workflow, the Maintainer coordinates handoffs between agents and provides clarifications as needed.
 
 ---
 
@@ -30,23 +30,23 @@ flowchart TB
 	classDef human fill:#f59e0b,stroke:#fbbf24,stroke-width:4px,color:#ffffff,rx:10,ry:10;
 
 	%% Human starting point (stadium shape for actor-like appearance)
-	HUMAN(["👤 <b>Developer</b><br/>(Human)"])
+	HUMAN(["👤 <b>Maintainer</b><br/>(Human)"])
 
 	%% Agents and artifacts in vertical order
-	SE["<b>Support Engineer</b>"]
+	IA_AGENT["<b>Issue Analyst</b>"]
 	IA["🔍 Issue Analysis"]
 	RE["<b>Requirements Engineer</b>"]
 	FS["📄 Feature Specification"]
 	AR["<b>Architect</b>"]
 	ADR["📐 Architecture Decision Records"]
-	PO["<b>Product Owner</b>"]
+	TP_AGENT["<b>Task Planner</b>"]
 	US["📋 User Stories / Tasks"]
 	QE["<b>Quality Engineer</b>"]
 	TP["✓ Test Plan & Test Cases"]
 	DEV["<b>Developer</b>"]
 	CODE["💻 Code & Tests"]
 	AN["🧪 Acceptance Notebooks"]
-	DOC["<b>Documentation Author</b>"]
+	TW["<b>Technical Writer</b>"]
 	DOCS["📚 Documentation"]
 	CR["<b>Code Reviewer</b>"]
 	CRR["✅ Code Review Report"]
@@ -59,24 +59,24 @@ flowchart TB
 	WD["⚙️ Workflow Documentation"]
 
 	%% Main vertical workflow with styled links
-	HUMAN == "Bug/Incident" ==> SE
+	HUMAN == "Bug/Incident" ==> IA_AGENT
 	HUMAN == "Feature Request" ==> RE
 	HUMAN == "Workflow Improvement" ==> WE
-	SE -- "Produces" --> IA
+	IA_AGENT -- "Produces" --> IA
 	IA -- "Consumed by" --> DEV
 	RE -- "Produces" --> FS
 	FS -- "Consumed by" --> AR
 	AR -- "Produces" --> ADR
 	ADR -- "Consumed by" --> QE
 	QE -- "Produces" --> TP
-	TP -- "Consumed by" --> PO
-	PO -- "Produces" --> US
+	TP -- "Consumed by" --> TP_AGENT
+	TP_AGENT -- "Produces" --> US
 	US -- "Consumed by" --> DEV
 	DEV -- "Produces" --> CODE
 	DEV -- "Produces" --> AN
-	CODE -- "Consumed by" --> DOC
+	CODE -- "Consumed by" --> TW
 	AN -- "Consumed by" --> CR
-	DOC -- "Produces" --> DOCS
+	TW -- "Produces" --> DOCS
 	DOCS -- "Consumed by" --> CR
 	CR -- "Produces" --> CRR
     CRR -- "Consumed by" --> DEV
@@ -94,32 +94,32 @@ flowchart TB
 	WE -- "Produces" --> WD
 	WE -. "Modifies" .-> RE
 	WE -. "Modifies" .-> AR
-	WE -. "Modifies" .-> PO
+	WE -. "Modifies" .-> TP_AGENT
 	WE -. "Modifies" .-> QE
 	WE -. "Modifies" .-> DEV
-	WE -. "Modifies" .-> DOC
+	WE -. "Modifies" .-> TW
 	WE -. "Modifies" .-> CR
 	WE -. "Modifies" .-> RM
 
 	%% Apply styles
 	class HUMAN human;
-	class SE,RE,AR,PO,QE,DEV,DOC,CR,RM agent;
+	class IA_AGENT,RE,AR,TP_AGENT,QE,DEV,TW,CR,RM agent;
 	class WE metaagent;
-	class IA,FS,US,ADR,TP,CODE,DOCS,CRR,REL,PR,WD artifact;
+	class IA,FS,US,ADR,TP,CODE,DOCS,CRR,REL,PR,WD,AN artifact;
 ```
 
 _Agents produce and consume artifacts. Arrows show artifact creation and consumption. Communication for feedback/questions between agents (regarding consumed artifacts) is always possible, but intentionally omitted from the diagram for clarity._
 
 **Linear Workflow:**
 
-1. **Support Engineer** investigates bugs, incidents, and technical problems.
+1. **Issue Analyst** investigates bugs, incidents, and technical problems.
 2. **Requirements Engineer** gathers and clarifies requirements for new features.
 3. **Architect** designs the solution and documents decisions.
 4. **Quality Engineer** defines the test plan and cases (consumes architecture). For user-facing features, defines acceptance scenarios for manual review.
-5. **Product Owner** creates and prioritizes actionable work items (consumes test plan).
-6. **Developer** implements features/fixes and tests. For user-facing features, creates acceptance notebooks for maintainer review.
-7. **Documentation Author** updates all relevant documentation (markdown files in the repository).
-8. **Code Reviewer** reviews and approves the work. Verifies acceptance notebooks execute successfully (maintainer reviews output separately).
+5. **Task Planner** creates and prioritizes actionable work items (consumes test plan).
+6. **Developer** implements features/fixes and tests. For user-facing features, creates acceptance notebooks for Maintainer review.
+7. **Technical Writer** updates all relevant documentation (markdown files in the repository).
+8. **Code Reviewer** reviews and approves the work. Verifies acceptance notebooks execute successfully (Maintainer reviews output separately).
 9. **Release Manager** prepares, coordinates, and executes the release.
 
 **Meta-Agent:**
@@ -143,22 +143,22 @@ _Agents produce and consume artifacts. Arrows show artifact creation and consump
 - **Key Behavior:** When multiple viable options exist, presents pros/cons with a recommendation and asks maintainer to choose the final approach.
 - **Definition of Done:** Architecture is documented and approved.
 
-### 4. Product Owner
-- **Goal:** Translate requirements and architecture into actionable work items.
-- **Deliverables:** User stories/tasks with acceptance criteria and priorities.
-- **Definition of Done:** Work items are clear, actionable, and prioritized.
-
 ### 4. Quality Engineer
 - **Goal:** Define how the feature will be tested and validated.
 - **Deliverables:** Test plan, test cases, quality criteria. For user-facing features, user acceptance scenarios for manual review.
 - **Definition of Done:** Test plan covers all acceptance criteria. User-facing features have clear acceptance scenarios defined.
 
+### 5. Task Planner
+- **Goal:** Translate requirements and architecture into actionable work items.
+- **Deliverables:** User stories/tasks with acceptance criteria and priorities.
+- **Definition of Done:** Work items are clear, actionable, and prioritized.
+
 ### 6. Developer
 - **Goal:** Implement features and tests as specified.
-- **Deliverables:** Code, tests, passing CI. For user-facing features, acceptance notebooks for maintainer review.
+- **Deliverables:** Code, tests, passing CI. For user-facing features, acceptance notebooks for Maintainer review.
 - **Definition of Done:** Code and tests meet requirements and pass all checks. User-facing features have interactive acceptance notebooks.
 
-### 7. Documentation Author
+### 7. Technical Writer
 - **Goal:** Update and maintain all relevant documentation.
 - **Deliverables:** Updated user and developer docs.
 - **Definition of Done:** Documentation is accurate and complete.
@@ -192,7 +192,7 @@ This section describes the purpose and format of each artifact produced and cons
 | **Architecture Decision Records (ADRs)** | Captures significant design decisions, alternatives considered, and rationale. Provides context for future maintainers. | Markdown following the ADR format: Context, Decision, Consequences. | `docs/adr-<number>-<short-title>.md` (high level / general decisions) and `docs/features/<feature-name>/architecture.md` (feature-specific decisions) |
 | **User Stories / Tasks** | Actionable work items with clear acceptance criteria. Used to track implementation progress. | Markdown document with: Title, Description, Acceptance Criteria checklist, Priority. | `docs/features/<feature-name>/tasks.md` |
 | **Test Plan & Test Cases** | Defines how the feature will be verified. Maps test cases to acceptance criteria. For user-facing features, includes user acceptance scenarios for manual review. | Markdown document with: Test Objectives, Test Cases (ID, Description, Steps, Expected Result), Coverage Matrix, User Acceptance Scenarios (for user-facing features). | `docs/features/<feature-name>/test-plan.md` |
-| **User Acceptance Notebooks** | Interactive demonstrations of user-facing features for manual maintainer review. Used to catch rendering bugs, validate real-world usage, and gather feedback before merge. | Polyglot Notebook (.dib) files with PowerShell code cells executing actual CLI commands and markdown narratives explaining expected behavior and validation criteria. | `docs/features/<feature-name>/acceptance/*.dib` |
+| **User Acceptance Notebooks** | Interactive demonstrations of user-facing features for manual Maintainer review. Used to catch rendering bugs, validate real-world usage, and gather feedback before merge. | Polyglot Notebook (.dib) files with PowerShell code cells executing actual CLI commands and markdown narratives explaining expected behavior and validation criteria. | `docs/features/<feature-name>/acceptance/*.dib` |
 | **Code & Tests** | Implementation of the feature including unit tests, integration tests, and any necessary refactoring. | Source code files following project conventions. Tests in `tests/` directory. | `src/` and `tests/` directories |
 | **Documentation** | Updated user-facing and developer documentation reflecting the new feature. | Markdown files following existing documentation structure. | `docs/`, `README.md` |
 | **Code Review Report** | Feedback on code quality, adherence to standards, and approval status. May request rework. | Markdown document with: Summary, Issues Found, Recommendations, Approval Status. | `docs/features/<feature-name>/code-review.md` |
@@ -209,10 +209,10 @@ Different types of work use different branch prefixes to maintain clarity:
 | Work Type | Branch Prefix | Example | Used By Agent |
 |-----------|---------------|---------|---------------|
 | Feature Development | `feature/` | `feature/123-firewall-diff-display` | Requirements Engineer, Developer |
-| Bug Fixes / Incidents | `fix/` | `fix/docker-hub-secret-in-release-workflow` | Support Engineer, Developer |
+| Bug Fixes / Incidents | `fix/` | `fix/docker-hub-secret-in-release-workflow` | Issue Analyst, Developer |
 | Workflow Improvements | `workflow/` | `workflow/add-security-agent` | Workflow Engineer |
 
-**Note:** The Requirements Engineer creates the feature branch at the start of the feature workflow. The Support Engineer creates the fix branch at the start of the bug fix workflow. All subsequent agents work on the same branch until Release Manager creates the pull request.
+**Note:** The Requirements Engineer creates the feature branch at the start of the feature workflow. The Issue Analyst creates the fix branch at the start of the bug fix workflow. All subsequent agents work on the same branch until Release Manager creates the pull request.
 
 ---
 
@@ -222,13 +222,13 @@ Each agent hands off to the next by producing a specific deliverable. The workfl
 
 | From Agent              | To Agent                | Handoff Trigger / Deliverable                        |
 |-------------------------|-------------------------|------------------------------------------------------|
-| Support Engineer        | Developer               | Issue Analysis with root cause and fix approach      |
+| Issue Analyst           | Developer               | Issue Analysis with root cause and fix approach      |
 | Requirements Engineer   | Architect               | Feature Specification                                |
 | Architect               | Quality Engineer        | Architecture Decision Records (ADRs)                 |
-| Quality Engineer        | Product Owner           | Test Plan & Test Cases                               |
-| Product Owner           | Developer               | User Stories / Tasks with Acceptance Criteria        |
-| Developer               | Documentation Author    | Code & Tests                                         |
-| Documentation Author    | Code Reviewer           | Updated Documentation                                |
+| Quality Engineer        | Task Planner            | Test Plan & Test Cases                               |
+| Task Planner            | Developer               | User Stories / Tasks with Acceptance Criteria        |
+| Developer               | Technical Writer        | Code & Tests                                         |
+| Technical Writer        | Code Reviewer           | Updated Documentation                                |
 | Code Reviewer           | Release Manager (approved) <br/> Developer (rework needed) | Code Review Report            |
 | Release Manager         | CI/CD Pipeline, GitHub  | Pull Request, Release Notes                          |
 
@@ -240,14 +240,14 @@ Handoffs are triggered when the deliverable is complete and meets the "Definitio
 
 ## Handoffs and Communication
 
-All agent coordination is managed by the **project maintainer**:
+All agent coordination is managed by the **Maintainer**:
 
-1. **Starting an agent** - The maintainer opens a new chat session in VS Code and selects the appropriate agent from the agents dropdown.
-2. **Providing context** - The maintainer points the agent to relevant artifacts from previous steps (e.g., "Review the specification in docs/features/X/specification.md").
+1. **Starting an agent** - The Maintainer opens a new chat session in VS Code and selects the appropriate agent from the agents dropdown.
+2. **Providing context** - The Maintainer points the agent to relevant artifacts from previous steps (e.g., "Review the specification in docs/features/X/specification.md").
 3. **Handoff buttons** - Agents provide handoff buttons that pre-fill prompts for the next agent in the workflow.
-4. **Feedback relay** - If an agent needs clarification from a previous step, it asks the maintainer, who either answers directly or relays the question to the appropriate agent.
+4. **Feedback relay** - If an agent needs clarification from a previous step, it asks the Maintainer, who either answers directly or relays the question to the appropriate agent.
 
-This approach keeps the workflow simple and gives the maintainer full visibility and control over all agent interactions.
+This approach keeps the workflow simple and gives the Maintainer full visibility and control over all agent interactions.
 
 ---
 
@@ -264,8 +264,8 @@ When the **Code Reviewer** requests changes, the following process applies:
 5. This cycle continues until the Code Reviewer approves.
 
 For significant rework that affects requirements or architecture:
-- The maintainer may need to consult the **Product Owner** or **Architect** agents for clarification.
-- If the rework reveals gaps in the original specification, the maintainer may return to the **Requirements Engineer** agent.
+- The Maintainer may need to consult the **Task Planner** or **Architect** agents for clarification.
+- If the rework reveals gaps in the original specification, the Maintainer may return to the **Requirements Engineer** agent.
 
 ---
 
@@ -273,8 +273,8 @@ For significant rework that affects requirements or architecture:
 
 Agents may encounter blockers or need clarification from previous steps. The following approach applies:
 
-- **Ask the maintainer** - Agents should clearly state what information is missing or what decision is needed.
-- **Maintainer relays** - The maintainer decides whether to answer directly or consult another agent.
+- **Ask the Maintainer** - Agents should clearly state what information is missing or what decision is needed.
+- **Maintainer relays** - The Maintainer decides whether to answer directly or consult another agent.
 - **Document blockers** - If work cannot proceed, the agent should document the blocker in its output and wait for resolution.
 
 This keeps all decisions traceable through the conversation history and artifact files.
@@ -286,7 +286,7 @@ This keeps all decisions traceable through the conversation history and artifact
 - **Clear Agent Boundaries:** Each agent should have a single responsibility and clear handoff criteria.
 - **Extensibility:** Design agents to be composable and customizable for different project needs.
 - **Traceability:** Document all decisions, requirements, and changes in artifact files.
-- **Maintainer Control:** The maintainer coordinates all handoffs and has final approval on all artifacts.
+- **Maintainer Control:** The Maintainer coordinates all handoffs and has final approval on all artifacts.
 - **Continuous Improvement:** Regularly review and refine agent roles and workflow.
 
 ---


### PR DESCRIPTION
## Overview
Renames three agents to better reflect their responsibilities and align with industry standards.

## Changes
- **Documentation Author → Technical Writer** - Standard industry title for documentation roles
- **Support Engineer → Issue Analyst** - Better reflects investigative/analytical nature of bug analysis
- **Product Owner → Task Planner** - More accurate for single-feature task breakdown (vs. multi-team product management)
- Updated all handoff references across agent definitions
- Consistently use 'Maintainer' for human coordinator role throughout documentation
- Updated Mermaid diagram and all workflow tables

## Rationale
- Eliminates ambiguity between human 'developer' and Developer agent
- Improves clarity and searchability of agent names
- Aligns with professional role naming conventions