### PR TITLE
feat(workflow): add one-command Azure DevOps PR script

### DIFF
--- a/.github/skills/create-pr-azdo/SKILL.md
+++ b/.github/skills/create-pr-azdo/SKILL.md
@@ -9,6 +9,8 @@ compatibility: Requires git, Azure CLI (az) with azure-devops extension, authent
 ## Purpose
 Create an Azure DevOps pull request in a consistent way, while still encoding the repository’s preference for a **linear history**.
 
+This skill prefers using the repo wrapper script `scripts/pr-azdo.sh` to minimize Maintainer approval interruptions (single terminal invocation).
+
 ## Notes on Merge Policy
 `CONTRIBUTING.md` specifies **Rebase and merge** as the required merge strategy for this repo.
 
@@ -25,6 +27,11 @@ Azure DevOps UI/merge options differ by project settings. When merging an Azure 
 - Merge using a strategy that introduces merge commits unless the Maintainer explicitly requests it.
 
 ## Actions
+
+### Recommended: One-Command Wrapper
+```bash
+scripts/pr-azdo.sh create --fill
+```
 
 ### 1. Pre-flight Checks
 ```bash

--- a/scripts/pr-azdo.sh
+++ b/scripts/pr-azdo.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Azure DevOps PR helper.
+# Goal: reduce Maintainer approval interruptions by running PR creation as a single stable command.
+
+AZDO_ORG="${AZDO_ORG:-https://dev.azure.com/oocx}"
+AZDO_PROJECT="${AZDO_PROJECT:-test}"
+AZDO_REPO="${AZDO_REPO:-test}"
+AZDO_REMOTE_NAME="${AZDO_REMOTE_NAME:-azdo}"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/pr-azdo.sh create --title <title> --description <text>
+  scripts/pr-azdo.sh create --fill
+
+Options:
+  --title <title>          PR title
+  --description <text>     PR description
+  --fill                   Derive title/description from git commits (best-effort)
+
+Environment:
+  AZDO_ORG                 Azure DevOps org URL (default: https://dev.azure.com/oocx)
+  AZDO_PROJECT             Azure DevOps project (default: test)
+  AZDO_REPO                Azure DevOps repo (default: test)
+  AZDO_REMOTE_NAME         git remote name used for pushing (default: azdo)
+
+Notes:
+  - Requires: git, Azure CLI (az) + azure-devops extension, jq
+  - Merge policy: maintain linear history. In Azure DevOps UI, pick the most rebase/linear option available.
+USAGE
+}
+
+require_clean_worktree() {
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Error: working tree has uncommitted changes." >&2
+    exit 2
+  fi
+}
+
+require_not_main() {
+  local branch
+  branch="$(git branch --show-current)"
+  if [[ "$branch" == "main" ]]; then
+    echo "Error: refusing to run on 'main'." >&2
+    exit 2
+  fi
+}
+
+ensure_azdo_auth() {
+  if ! az account show >/dev/null 2>&1; then
+    echo "Error: not authenticated. Run: az login" >&2
+    exit 2
+  fi
+
+  if ! az extension show --name azure-devops >/dev/null 2>&1; then
+    echo "azure-devops extension not found; installing..." >&2
+    az extension add --name azure-devops >/dev/null
+  fi
+
+  az devops configure --defaults organization="$AZDO_ORG" project="$AZDO_PROJECT" >/dev/null
+}
+
+ensure_remote() {
+  if git remote get-url "$AZDO_REMOTE_NAME" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # Same remote URL format used by scripts/uat-azdo.sh
+  git remote add "$AZDO_REMOTE_NAME" "https://oocx@dev.azure.com/oocx/$AZDO_PROJECT/_git/$AZDO_REPO"
+}
+
+derive_from_git() {
+  # Best-effort: first line of last commit as title, body as description.
+  # If there is only a single line, description becomes empty.
+  local msg
+  msg="$(git log -1 --pretty=%B)"
+  TITLE="$(printf '%s' "$msg" | head -n 1)"
+  DESCRIPTION="$(printf '%s' "$msg" | tail -n +2 | sed '/^\s*$/d' || true)"
+
+  if [[ -z "$TITLE" ]]; then
+    TITLE="workflow: update"
+  fi
+
+  if [[ -z "$DESCRIPTION" ]]; then
+    DESCRIPTION="Created by scripts/pr-azdo.sh."
+  fi
+}
+
+parse_args() {
+  local cmd="$1"
+  shift
+
+  TITLE=""
+  DESCRIPTION=""
+  FILL="false"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --title)
+        TITLE="$2"
+        shift 2
+        ;;
+      --description)
+        DESCRIPTION="$2"
+        shift 2
+        ;;
+      --fill)
+        FILL="true"
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Error: unknown arg: $1" >&2
+        usage
+        exit 2
+        ;;
+    esac
+  done
+
+  if [[ "$cmd" != "create" ]]; then
+    echo "Error: unknown command: $cmd" >&2
+    usage
+    exit 2
+  fi
+
+  if [[ "$FILL" == "true" ]]; then
+    derive_from_git
+  else
+    if [[ -z "$TITLE" || -z "$DESCRIPTION" ]]; then
+      echo "Error: provide --fill OR both --title and --description." >&2
+      usage
+      exit 2
+    fi
+  fi
+}
+
+create_pr() {
+  local branch
+  branch="$(git branch --show-current)"
+
+  ensure_remote
+  echo "Pushing branch '$branch' to Azure DevOps remote '$AZDO_REMOTE_NAME'..." >&2
+  git push -u "$AZDO_REMOTE_NAME" HEAD:"$branch" --force
+
+  echo "Creating PR in Azure DevOps..." >&2
+  local pr_json
+  pr_json="$(az repos pr create \
+    --organization "$AZDO_ORG" \
+    --project "$AZDO_PROJECT" \
+    --repository "$AZDO_REPO" \
+    --source-branch "$branch" \
+    --target-branch main \
+    --title "$TITLE" \
+    --description "$DESCRIPTION" \
+    --output json)"
+
+  local pr_id
+  pr_id="$(printf '%s' "$pr_json" | jq -r '.pullRequestId')"
+
+  echo "PR created: #$pr_id" >&2
+  echo "URL: $AZDO_ORG/$AZDO_PROJECT/_git/$AZDO_REPO/pullrequest/$pr_id" >&2
+  echo "" >&2
+  echo "Merge guidance (linear history):" >&2
+  echo "- In Azure DevOps UI, choose the most rebase/linear merge option available (often 'Rebase and fast-forward')." >&2
+  echo "- Avoid squash/merge commits unless Maintainer requests otherwise." >&2
+}
+
+main() {
+  if [[ $# -lt 1 ]]; then
+    usage
+    exit 2
+  fi
+
+  local cmd="$1"
+  shift
+
+  require_not_main
+  require_clean_worktree
+
+  if ! command -v az >/dev/null 2>&1; then
+    echo "Error: az is not installed." >&2
+    exit 2
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is not installed." >&2
+    exit 2
+  fi
+
+  ensure_azdo_auth
+  parse_args "$cmd" "$@"
+
+  create_pr
+}
+
+main "$@"


### PR DESCRIPTION
Add scripts/pr-azdo.sh wrapper to push and create Azure DevOps PRs in one stable command.

Update create-pr-azdo skill to prefer the wrapper to reduce approval interruptions.
