### PR TITLE
feat(workflow): add azdo PR abandon wrapper

### DIFF
--- a/.github/skills/create-pr-azdo/SKILL.md
+++ b/.github/skills/create-pr-azdo/SKILL.md
@@ -33,6 +33,11 @@ Azure DevOps UI/merge options differ by project settings. When merging an Azure 
 scripts/pr-azdo.sh create --fill
 ```
 
+Abandon a test PR (cleanup):
+```bash
+scripts/pr-azdo.sh abandon --id <pr-id>
+```
+
 ### 1. Pre-flight Checks
 ```bash
 git branch --show-current


### PR DESCRIPTION
Extend scripts/pr-azdo.sh with an abandon subcommand for cleanup.

Update create-pr-azdo skill to document one-command cleanup.
