### PR TITLE
feat(workflow): add UAT PR watch skills

### DIFF
--- a/.github/skills/watch-uat-azdo-pr/SKILL.md
+++ b/.github/skills/watch-uat-azdo-pr/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: watch-uat-azdo-pr
+description: Watch an Azure DevOps UAT PR for maintainer feedback or approval by polling threads and reviewer votes until approved/passed.
+compatibility: Requires Azure CLI (az) with azure-devops extension, authentication, jq, and network access.
+---
+
+# Watch UAT PR (Azure DevOps)
+
+## Purpose
+UAT polling is historically brittle. This skill standardizes the watch loop so the agent can reliably wait for Maintainer feedback/approval using a single stable command.
+
+This skill uses the repo wrapper script `scripts/uat-watch-azdo.sh`, which repeatedly calls `scripts/uat-azdo.sh poll` until:
+- PR status becomes `completed`, or
+- an approval vote is detected, or
+- approval keywords are detected in non-agent comments, or
+- a timeout is reached.
+
+## Hard Rules
+### Must
+- Use `scripts/uat-watch-azdo.sh` (single stable command).
+- Prefer reviewer votes / PR completion as the strongest approval signal.
+
+### Must Not
+- Spam threads or post follow-ups while waiting.
+- Run many ad-hoc `az`/`az devops invoke` calls; prefer the wrapper.
+
+## Actions
+
+### 1. Watch the PR
+```bash
+scripts/uat-watch-azdo.sh <pr-id>
+```
+
+### 2. Optional: Tune polling interval / timeout
+```bash
+scripts/uat-watch-azdo.sh <pr-id> --interval-seconds 60 --timeout-seconds 3600
+```
+
+## Output
+- Exit code `0`: approval detected / PR completed (treat as pass)
+- Exit code `1`: timed out (treat as incomplete; ask Maintainer)

--- a/.github/skills/watch-uat-github-pr/SKILL.md
+++ b/.github/skills/watch-uat-github-pr/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: watch-uat-github-pr
+description: Watch a GitHub UAT PR for maintainer feedback or approval by polling comments until approved/passed.
+compatibility: Requires GitHub CLI (gh) authenticated, plus network access.
+---
+
+# Watch UAT PR (GitHub)
+
+## Purpose
+UAT comment polling is historically brittle. This skill standardizes the watch loop so the agent can reliably wait for Maintainer feedback/approval using a single stable command.
+
+This skill uses the repo wrapper script `scripts/uat-watch-github.sh`, which repeatedly calls `scripts/uat-github.sh poll` until:
+- approval keywords are detected, or
+- the PR is closed/merged, or
+- a timeout is reached.
+
+## Hard Rules
+### Must
+- Use `scripts/uat-watch-github.sh` (single stable command).
+- Treat any detected approval (`approved|passed|accept|lgtm`) as UAT passed.
+- Stop watching and report when the PR is closed.
+
+### Must Not
+- Spam comments or post follow-ups while waiting.
+- Run many ad-hoc `gh` commands; prefer the wrapper.
+
+## Actions
+
+### 1. Watch the PR
+```bash
+scripts/uat-watch-github.sh <pr-number>
+```
+
+### 2. Optional: Tune polling interval / timeout
+```bash
+scripts/uat-watch-github.sh <pr-number> --interval-seconds 60 --timeout-seconds 3600
+```
+
+## Output
+- Exit code `0`: approval detected or PR closed (treat as pass)
+- Exit code `1`: timed out (treat as incomplete; ask Maintainer)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -35,6 +35,8 @@ When authoring skills, prefer designs that **minimize Maintainer approval interr
 | `generate-demo-artifacts` | Generate the comprehensive demo markdown artifact from the current codebase. |
 | `run-uat` | Run User Acceptance Testing by creating a PR with rendered markdown on GitHub or Azure DevOps. |
 | `simulate-uat` | Simulate the UAT workflow (create PR, comment, poll) on GitHub or Azure DevOps using a minimal test artifact and simulated fixes. |
+| `watch-uat-github-pr` | Watch a GitHub UAT PR for maintainer feedback or approval by polling comments until approved/passed. |
+| `watch-uat-azdo-pr` | Watch an Azure DevOps UAT PR for maintainer feedback or approval by polling threads and reviewer votes until approved/passed. |
 
 ---
 

--- a/scripts/uat-watch-azdo.sh
+++ b/scripts/uat-watch-azdo.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/uat-watch-azdo.sh <pr-id> [--interval-seconds <n>] [--timeout-seconds <n>]
+
+Watches an Azure DevOps PR for maintainer feedback/approval by repeatedly calling:
+  scripts/uat-azdo.sh poll <pr-id>
+
+Exit codes:
+  0  Approval detected / PR completed
+  1  Timed out waiting for approval
+  2  Invalid usage / missing dependency
+
+Defaults:
+  --interval-seconds 60
+  --timeout-seconds  3600
+
+Notes:
+  - Requires: az authenticated + azure-devops extension
+  - Designed to be a single stable command to minimize approvals.
+USAGE
+}
+
+main() {
+  if [[ $# -lt 1 ]]; then
+    usage
+    exit 2
+  fi
+
+  local pr_id="$1"
+  shift
+
+  local interval_seconds=60
+  local timeout_seconds=3600
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --interval-seconds)
+        interval_seconds="$2"
+        shift 2
+        ;;
+      --timeout-seconds)
+        timeout_seconds="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Error: unknown arg: $1" >&2
+        usage
+        exit 2
+        ;;
+    esac
+  done
+
+  if ! command -v az >/dev/null 2>&1; then
+    echo "Error: az is not installed." >&2
+    exit 2
+  fi
+
+  if ! az account show >/dev/null 2>&1; then
+    echo "Error: az is not authenticated. Run: az login" >&2
+    exit 2
+  fi
+
+  local start
+  start="$(date +%s)"
+  local deadline=$((start + timeout_seconds))
+
+  while true; do
+    if scripts/uat-azdo.sh poll "$pr_id"; then
+      exit 0
+    fi
+
+    local now
+    now="$(date +%s)"
+    if (( now >= deadline )); then
+      echo "Timed out waiting for approval (PR #$pr_id)." >&2
+      exit 1
+    fi
+
+    sleep "$interval_seconds"
+  done
+}
+
+main "$@"

--- a/scripts/uat-watch-github.sh
+++ b/scripts/uat-watch-github.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/uat-watch-github.sh <pr-number> [--interval-seconds <n>] [--timeout-seconds <n>]
+
+Watches a GitHub PR for maintainer feedback/approval by repeatedly calling:
+  scripts/uat-github.sh poll <pr-number>
+
+Exit codes:
+  0  Approval detected / PR closed
+  1  Timed out waiting for approval
+  2  Invalid usage / missing dependency
+
+Defaults:
+  --interval-seconds 60
+  --timeout-seconds  3600
+
+Notes:
+  - Requires: gh authenticated
+  - Designed to be a single stable command to minimize approvals.
+USAGE
+}
+
+main() {
+  if [[ $# -lt 1 ]]; then
+    usage
+    exit 2
+  fi
+
+  local pr_number="$1"
+  shift
+
+  local interval_seconds=60
+  local timeout_seconds=3600
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --interval-seconds)
+        interval_seconds="$2"
+        shift 2
+        ;;
+      --timeout-seconds)
+        timeout_seconds="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Error: unknown arg: $1" >&2
+        usage
+        exit 2
+        ;;
+    esac
+  done
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: gh is not installed." >&2
+    exit 2
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: gh is not authenticated. Run: gh auth login" >&2
+    exit 2
+  fi
+
+  local start
+  start="$(date +%s)"
+  local deadline=$((start + timeout_seconds))
+
+  while true; do
+    if scripts/uat-github.sh poll "$pr_number"; then
+      exit 0
+    fi
+
+    local now
+    now="$(date +%s)"
+    if (( now >= deadline )); then
+      echo "Timed out waiting for approval (PR #$pr_number)." >&2
+      exit 1
+    fi
+
+    sleep "$interval_seconds"
+  done
+}
+
+main "$@"


### PR DESCRIPTION
Add stable wrapper scripts and skills to watch UAT PRs for approval.

- GitHub: scripts/uat-watch-github.sh + watch-uat-github-pr
- Azure DevOps: scripts/uat-watch-azdo.sh + watch-uat-azdo-pr
- Register skills in docs/agents.md
