### PR TITLE
docs(workflow): show PR title and summary before create

### DIFF
--- a/.github/skills/create-pr-azdo/SKILL.md
+++ b/.github/skills/create-pr-azdo/SKILL.md
@@ -22,11 +22,19 @@ Azure DevOps UI/merge options differ by project settings. When merging an Azure 
 - Ensure the working tree is clean before creating a PR.
 - Push the branch before creating the PR.
 - Keep PR title and description conventional and review-friendly.
+- Before creating the PR, post a short PR preview in chat:
+  - **Title**: the exact PR title you plan to use
+  - **Summary**: 1–3 bullets describing the change
 
 ### Must Not
 - Merge using a strategy that introduces merge commits unless the Maintainer explicitly requests it.
 
 ## Actions
+
+### 0. PR Preview (Required)
+Before running any PR creation command, provide in chat:
+- **PR title** (exact)
+- **PR summary** (1–3 bullets)
 
 ### Recommended: One-Command Wrapper
 ```bash

--- a/.github/skills/create-pr-github/SKILL.md
+++ b/.github/skills/create-pr-github/SKILL.md
@@ -16,6 +16,9 @@ This skill prefers using the repo wrapper script `scripts/pr-github.sh` to minim
 - Work on a non-`main` branch.
 - Ensure the working tree is clean before creating a PR.
 - Push the branch to `origin` before creating the PR.
+- Before creating the PR, post a short PR preview in chat:
+  - **Title**: the exact PR title you plan to use
+  - **Summary**: 1–3 bullets describing the change
 - Use **Rebase and merge** for merging PRs to maintain a linear history (see `CONTRIBUTING.md`).
 
 ### Must Not
@@ -23,6 +26,11 @@ This skill prefers using the repo wrapper script `scripts/pr-github.sh` to minim
 - Use “Squash and merge” or “Create a merge commit”.
 
 ## Actions
+
+### 0. PR Preview (Required)
+Before running any PR creation command, provide in chat:
+- **PR title** (exact)
+- **PR summary** (1–3 bullets)
 
 ### Recommended: One-Command Wrapper
 Create a PR:


### PR DESCRIPTION
## Summary
This PR updates the PR creation skills to require a short chat preview before running PR creation commands.

- Agents must post the exact PR title and a 1–3 bullet summary in chat before invoking PR creation.
- Applies to both GitHub and Azure DevOps PR creation skills.

## Why
This makes it easier to decide whether to allow PR creation when Copilot requests terminal permissions.
