### PR TITLE
feat(workflow): add uat-run wrapper and artifact guardrails

### DIFF
--- a/.github/agents/uat-tester.agent.md
+++ b/.github/agents/uat-tester.agent.md
@@ -26,7 +26,8 @@ Validate that generated markdown renders correctly in real-world PR environments
 ## Boundaries
 
 ### ✅ Always Do
-- Use `scripts/uat-github.sh` and `scripts/uat-azdo.sh` for all UAT operations
+- Prefer `scripts/uat-run.sh` for end-to-end UAT (single stable command)
+- Use `scripts/uat-github.sh` and `scripts/uat-azdo.sh` for targeted operations / debugging
 - Post markdown as **PR comments** (not PR description)
 - Prefix comments with agent identifier (scripts do this automatically)
 - Post fixes to **BOTH platforms** when feedback is received on either
@@ -50,7 +51,7 @@ Validate that generated markdown renders correctly in real-world PR environments
 - Perform any verification beyond visual rendering in PRs
 - Run unrelated tasks while waiting for feedback
 - Use background polling (`nohup`, `&`) — poll in the foreground and act immediately on results
-- Use wrapper scripts like `uat-runner.sh` — always follow the step-by-step process below
+- Bypass the UAT artifact guardrails (do not set `UAT_ALLOW_MINIMAL=1` for real UAT)
 
 ### ⚠️ CRITICAL: Autonomous Execution
 

--- a/.github/skills/run-uat/SKILL.md
+++ b/.github/skills/run-uat/SKILL.md
@@ -28,6 +28,19 @@ Execute end-to-end User Acceptance Testing by posting the comprehensive demo art
 
 ## Actions
 
+### Recommended: Single Wrapper Command
+This repository provides a stable wrapper that creates UAT PR(s), polls for approval, and cleans up in one command.
+
+```bash
+scripts/uat-run.sh artifacts/comprehensive-demo.md
+```
+
+If you need to target only one platform:
+```bash
+scripts/uat-run.sh artifacts/comprehensive-demo.md --platform github
+scripts/uat-run.sh artifacts/comprehensive-demo.md --platform azdo
+```
+
 ### 0. Recommended: Rebase on Latest Main
 Before running UAT, ensure your branch is up to date to avoid testing against stale base changes.
 Use the `git-rebase-main` skill.

--- a/.github/skills/simulate-uat/SKILL.md
+++ b/.github/skills/simulate-uat/SKILL.md
@@ -140,7 +140,7 @@ git push -u origin HEAD
 ### 3. Run GitHub Simulation
 ```bash
 # Create PR with simulation label
-scripts/uat-github.sh create artifacts/uat-simulation.md
+UAT_ALLOW_MINIMAL=1 scripts/uat-github.sh create artifacts/uat-simulation.md
 # PR title will be: "UAT: uat-minimal"
 
 # Poll for comments/feedback
@@ -181,7 +181,7 @@ scripts/uat-github.sh cleanup <pr-number>
 ### 4. Run Azure DevOps Simulation
 ```bash
 scripts/uat-azdo.sh setup
-scripts/uat-azdo.sh create artifacts/uat-simulation.md
+UAT_ALLOW_MINIMAL=1 scripts/uat-azdo.sh create artifacts/uat-simulation.md
 scripts/uat-azdo.sh poll <pr-id>
 # Handle feedback with simulated response file
 scripts/uat-azdo.sh comment <pr-id> /tmp/uat-simulated-fix.md

--- a/scripts/uat-azdo.sh
+++ b/scripts/uat-azdo.sh
@@ -55,7 +55,19 @@ cmd_create() {
         log_error "Usage: $0 create <markdown-file>"
         exit 1
     fi
+
+    # Guardrail: prevent accidental posting of minimal/simulation artifacts for real UAT.
+    # Override by setting UAT_ALLOW_MINIMAL=1 (intended for simulate-uat).
+    if [[ "${UAT_ALLOW_MINIMAL:-}" != "1" ]]; then
+        if echo "$(basename "$file")" | grep -qiE '(minimal|simulation)'; then
+            log_error "Refusing to use a minimal/simulation artifact for real UAT: $file"
+            log_error "Use artifacts/comprehensive-demo.md (recommended), or set UAT_ALLOW_MINIMAL=1 to override."
+            exit 1
+        fi
+    fi
     
+    log_info "Using artifact: $file"
+
     local branch
     branch=$(git branch --show-current)
     local title="UAT: $(basename "$file" .md)"

--- a/scripts/uat-github.sh
+++ b/scripts/uat-github.sh
@@ -26,11 +26,22 @@ cmd_create() {
         log_error "Usage: $0 create <markdown-file>"
         exit 1
     fi
+
+    # Guardrail: prevent accidental posting of minimal/simulation artifacts for real UAT.
+    # Override by setting UAT_ALLOW_MINIMAL=1 (intended for simulate-uat).
+    if [[ "${UAT_ALLOW_MINIMAL:-}" != "1" ]]; then
+        if echo "$(basename "$file")" | grep -qiE '(minimal|simulation)'; then
+            log_error "Refusing to use a minimal/simulation artifact for real UAT: $file"
+            log_error "Use artifacts/comprehensive-demo.md (recommended), or set UAT_ALLOW_MINIMAL=1 to override."
+            exit 1
+        fi
+    fi
     
     local branch
     branch=$(git branch --show-current)
     local title="UAT: $(basename "$file" .md)"
     
+    log_info "Using artifact: $file"
     log_info "Pushing branch to GitHub..."
     git push -u origin HEAD --force
     

--- a/scripts/uat-run.sh
+++ b/scripts/uat-run.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# UAT Wrapper Script (GitHub + Azure DevOps)
+#
+# Purpose: Reduce Maintainer approval fatigue by batching UAT into one stable command.
+#
+# Usage:
+#   scripts/uat-run.sh <artifact-path> [--platform both|github|azdo]
+#
+# Notes:
+# - Creates a temporary, unique UAT branch off the current branch.
+# - Creates UAT PR(s), polls for approval, then cleans up PR(s) and branches.
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+die_usage() {
+  log_error "Usage: $0 <artifact-path> [--platform both|github|azdo]"
+  exit 2
+}
+
+artifact="${1:-}"
+shift || true
+
+platform="both"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --platform)
+      platform="${2:-}"
+      shift 2
+      ;;
+    *)
+      die_usage
+      ;;
+  esac
+done
+
+if [[ -z "$artifact" ]]; then
+  die_usage
+fi
+
+if [[ ! -f "$artifact" ]]; then
+  log_error "Artifact not found: $artifact"
+  exit 1
+fi
+
+if [[ "$platform" != "both" && "$platform" != "github" && "$platform" != "azdo" ]]; then
+  log_error "Invalid --platform value: $platform"
+  die_usage
+fi
+
+original_branch="$(git branch --show-current)"
+if [[ "$original_branch" == "main" ]]; then
+  log_error "Refusing to run UAT from 'main'. Switch to a feature branch first."
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  log_error "Working tree is not clean. Commit or stash changes before running UAT."
+  exit 1
+fi
+
+# Artifact guardrails: prevent accidental posting of minimal/simulation artifacts.
+# Override by setting UAT_ALLOW_MINIMAL=1 (intended for simulate-uat).
+if [[ "${UAT_ALLOW_MINIMAL:-}" != "1" ]]; then
+  if echo "$(basename "$artifact")" | grep -qiE '(minimal|simulation)'; then
+    log_error "Refusing to use a minimal/simulation artifact for real UAT: $artifact"
+    log_error "Use artifacts/comprehensive-demo.md (recommended), or set UAT_ALLOW_MINIMAL=1 to override."
+    exit 1
+  fi
+fi
+
+log_info "Using artifact: $artifact"
+
+timestamp="$(date -u +%Y%m%d%H%M%S)"
+# Create a unique, safe UAT branch name.
+# Example: uat/feature-foo-uat-20251225205901
+safe_original="${original_branch//\//-}"
+uat_branch="uat/${safe_original}-uat-${timestamp}"
+
+cleanup_on_exit() {
+  # Best-effort restore if something fails.
+  if git rev-parse --verify "$original_branch" >/dev/null 2>&1; then
+    git switch "$original_branch" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup_on_exit EXIT
+
+log_info "Creating UAT branch: $uat_branch"
+git switch -c "$uat_branch" >/dev/null
+
+gh_pr=""
+azdo_pr=""
+
+if [[ "$platform" == "both" || "$platform" == "github" ]]; then
+  log_info "Creating GitHub UAT PR..."
+  gh_out="$(scripts/uat-github.sh create "$artifact" | cat)"
+  gh_pr="$(echo "$gh_out" | grep -oE 'PR created: #[0-9]+' | grep -oE '[0-9]+' | tail -n 1)"
+  if [[ -z "$gh_pr" ]]; then
+    log_error "Failed to parse GitHub PR number from output."
+    exit 1
+  fi
+  log_info "GitHub PR: #$gh_pr"
+fi
+
+if [[ "$platform" == "both" || "$platform" == "azdo" ]]; then
+  log_info "Ensuring Azure DevOps setup..."
+  scripts/uat-azdo.sh setup
+
+  log_info "Creating Azure DevOps UAT PR..."
+  azdo_out="$(scripts/uat-azdo.sh create "$artifact" | cat)"
+  azdo_pr="$(echo "$azdo_out" | grep -oE 'PR created: #[0-9]+' | grep -oE '[0-9]+' | tail -n 1)"
+  if [[ -z "$azdo_pr" ]]; then
+    log_error "Failed to parse Azure DevOps PR id from output."
+    exit 1
+  fi
+  log_info "Azure DevOps PR: #$azdo_pr"
+fi
+
+poll_interval_seconds=15
+timeout_seconds=$((60 * 60))
+start_epoch="$(date +%s)"
+
+while true; do
+  now_epoch="$(date +%s)"
+  elapsed=$((now_epoch - start_epoch))
+  if [[ $elapsed -gt $timeout_seconds ]]; then
+    log_error "Timed out waiting for approval after $elapsed seconds."
+    log_error "Check the PR comments for feedback and re-run once resolved."
+    exit 1
+  fi
+
+  gh_ok=0
+  azdo_ok=0
+
+  if [[ -n "$gh_pr" ]]; then
+    scripts/uat-github.sh poll "$gh_pr" && gh_ok=1 || gh_ok=0
+  else
+    gh_ok=1
+  fi
+
+  if [[ -n "$azdo_pr" ]]; then
+    scripts/uat-azdo.sh poll "$azdo_pr" && azdo_ok=1 || azdo_ok=0
+  else
+    azdo_ok=1
+  fi
+
+  if [[ $gh_ok -eq 1 && $azdo_ok -eq 1 ]]; then
+    log_info "UAT approved on selected platform(s)."
+    break
+  fi
+
+  sleep "$poll_interval_seconds"
+done
+
+log_info "Cleaning up UAT PRs..."
+if [[ -n "$gh_pr" ]]; then
+  scripts/uat-github.sh cleanup "$gh_pr"
+fi
+
+if [[ -n "$azdo_pr" ]]; then
+  scripts/uat-azdo.sh cleanup "$azdo_pr"
+fi
+
+log_info "Deleting GitHub remote branch: $uat_branch"
+git push origin --delete "$uat_branch" >/dev/null 2>&1 || log_warn "Failed to delete origin/$uat_branch (may already be deleted)."
+
+log_info "Restoring original branch: $original_branch"
+git switch "$original_branch" >/dev/null
+
+log_info "Deleting local UAT branch: $uat_branch"
+git branch -D "$uat_branch" >/dev/null 2>&1 || true
+
+log_info "UAT run complete."


### PR DESCRIPTION
## Summary
Adds a single wrapper command for UAT and makes it harder to accidentally post the wrong artifact during UAT.

- Adds `scripts/uat-run.sh` to orchestrate GitHub + Azure DevOps UAT create/comment/poll/cleanup.
- Adds artifact guardrails in `scripts/uat-github.sh` and `scripts/uat-azdo.sh` to reduce “wrong artifact” mistakes.
- Updates UAT guidance to prefer the wrapper (`UAT Tester` agent + `run-uat`/`simulate-uat` skills).

## Why
This directly addresses the retrospective feedback about excessive terminal approvals during UAT and accidental use of the wrong artifact.
