### PR TITLE
docs(workflow): link latest retrospective follow-ups

### DIFF
--- a/docs/features/consistent-value-formatting/retrospective.md
+++ b/docs/features/consistent-value-formatting/retrospective.md
@@ -93,13 +93,13 @@ This section tracks follow-up implementation progress from this retrospective.
 
 | Item | Status | PRs / Notes |
 |---|---|---|
-| Reduce manual approvals via stable wrappers | ✅ Partial | GitHub PR wrapper added ([#87](https://github.com/oocx/tfplan2md/pull/87)); Azure DevOps PR wrapper added ([#88](https://github.com/oocx/tfplan2md/pull/88)); AzDO abandon cleanup added ([#89](https://github.com/oocx/tfplan2md/pull/89)). Dedicated end-to-end `scripts/uat-run.sh` wrapper still not implemented. |
+| Reduce manual approvals via stable wrappers | ✅ Partial | GitHub PR wrapper added ([#87](https://github.com/oocx/tfplan2md/pull/87)); Azure DevOps PR wrapper added ([#88](https://github.com/oocx/tfplan2md/pull/88)); AzDO abandon cleanup added ([#89](https://github.com/oocx/tfplan2md/pull/89)); end-to-end UAT wrapper added ([#95](https://github.com/oocx/tfplan2md/pull/95)). |
 | Make PR feedback polling less brittle | ✅ Partial | UAT PR watch scripts/skills added ([#90](https://github.com/oocx/tfplan2md/pull/90)); GitHub UAT poll hardened to use JSON queries and filter agent comments ([#92](https://github.com/oocx/tfplan2md/pull/92)). |
-| Reduce Maintainer “Allow” uncertainty | ✅ Done | PR creation skills now require agents to present PR title + short summary in chat before running PR creation commands ([#93](https://github.com/oocx/tfplan2md/pull/93)). |
+| Reduce Maintainer “Allow” uncertainty | ✅ Done | PR creation skills now require agents to present PR title + short summary in chat before running PR creation commands ([#93](https://github.com/oocx/tfplan2md/pull/93)); wrapper scripts add a `preview` command to help generate the chat preview consistently ([#96](https://github.com/oocx/tfplan2md/pull/96)). |
 | Skill authoring guidance (approval minimization) | ✅ Done | Added explicit guidance to prefer stable wrapper commands to reduce approvals ([#86](https://github.com/oocx/tfplan2md/pull/86)). |
 | UAT run/simulate skills foundation | ✅ Done | Initial UAT-related skills and scripts registered in workflow docs ([#85](https://github.com/oocx/tfplan2md/pull/85)). |
 | Standard metrics section in retrospectives | ✅ Done | Added/standardized metrics guidance in workflow docs/retrospective artifacts ([#84](https://github.com/oocx/tfplan2md/pull/84)). |
-| Guardrails against wrong UAT artifact | ⏳ Not started | Still needs script enforcement + UAT agent defaulting to the canonical artifact. |
+| Guardrails against wrong UAT artifact | ✅ Partial | Added guardrails in UAT scripts and updated UAT guidance to prefer the UAT wrapper ([#95](https://github.com/oocx/tfplan2md/pull/95)). Canonical artifact enforcement still pending. |
 | Doc alignment gate in Code Review | ⏳ Not started | Still needs an explicit checklist gate covering spec/tasks/test plan alignment. |
 | Role boundaries + handoff/status templates | ⏳ Not started | Still needs enforcement in agent definitions. |
 | Wire report style guide into agents | ⏳ Not started | Still needs agent-doc references/requirements. |

--- a/docs/roadmap-workflow-improvements-2025-q4.md
+++ b/docs/roadmap-workflow-improvements-2025-q4.md
@@ -23,8 +23,8 @@ This roadmap outlines a series of workflow improvements derived from the "Consis
 - ✅ Added stable wrapper scripts to reduce ad-hoc commands: GitHub ([#87](https://github.com/oocx/tfplan2md/pull/87)), Azure DevOps ([#88](https://github.com/oocx/tfplan2md/pull/88)), AzDO abandon cleanup ([#89](https://github.com/oocx/tfplan2md/pull/89))
 - ✅ Added UAT watch scripts/skills for polling: ([#90](https://github.com/oocx/tfplan2md/pull/90))
 - ✅ Hardened GitHub UAT polling to use structured JSON and filter agent comments: ([#92](https://github.com/oocx/tfplan2md/pull/92))
-- ⏳ `scripts/uat-run.sh` wrapper (single end-to-end UAT command) not implemented yet
-- ⏳ Guardrails against wrong artifacts + canonical artifact enforcement not implemented yet
+- ✅ Added `scripts/uat-run.sh` end-to-end wrapper (GitHub + AzDO orchestration): ([#95](https://github.com/oocx/tfplan2md/pull/95))
+- ✅ Added initial guardrails against wrong artifacts in UAT scripts (canonical artifact enforcement still pending): ([#95](https://github.com/oocx/tfplan2md/pull/95))
 
 ## 2. 🤝 Agent Communication & Role Clarity
 
@@ -55,6 +55,7 @@ This roadmap outlines a series of workflow improvements derived from the "Consis
 **Progress**
 - ✅ Added skill design guidance to minimize Maintainer approvals (prefer stable wrapper commands): ([#86](https://github.com/oocx/tfplan2md/pull/86))
 - ✅ PR creation skills now require a chat preview (title + summary) before creating PRs: ([#93](https://github.com/oocx/tfplan2md/pull/93))
+- ✅ Wrapper scripts add a `preview` helper command to generate the chat preview consistently: ([#96](https://github.com/oocx/tfplan2md/pull/96))
 - ⏳ Doc alignment gate in Code Review not implemented yet
 - ⏳ Report style guide wiring into agent instructions not implemented yet
 - ⏳ Release Manager merge-method enforcement not implemented yet


### PR DESCRIPTION
## Summary
Keeps the retrospective/roadmap progress trackers up to date with the latest merged PRs.

- Links PR #95 (uat-run wrapper + UAT artifact guardrails) into the progress tables.
- Links PR #96 (PR preview helper commands) into the progress tables.
