### PR TITLE
fix(workflow): fix Husky commit-msg args variable

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -19,8 +19,9 @@
       "command": "bash",
       "args": [
         "-c",
-        "if ! grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\(.+\\))?!?: .{1,}$' \"${args[0]}\"; then echo 'ERROR: Commit message does not follow Conventional Commits format.' && echo 'Expected: <type>[optional scope]: <description>' && echo 'Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert' && echo '' && echo 'Your message:' && cat \"${args[0]}\" && exit 1; fi",
-        "${args[0]}"
+        "if ! grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\(.+\\))?!?: .{1,}$' \"$1\"; then echo 'ERROR: Commit message does not follow Conventional Commits format.' && echo 'Expected: <type>[optional scope]: <description>' && echo 'Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert' && echo '' && echo 'Your message:' && cat \"$1\" && exit 1; fi",
+        "--",
+        "${args}"
       ],
       "windows": {
         "command": "pwsh",
@@ -28,7 +29,7 @@
           "-NoProfile",
           "-Command",
           "$msg = Get-Content $args[0] -Raw; if ($msg -notmatch '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\(.+\\))?!?: .{1,}') { Write-Error 'Commit message does not follow Conventional Commits format.'; Write-Host 'Expected: <type>[optional scope]: <description>'; Write-Host 'Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert'; exit 1 }",
-          "${args[0]}"
+          "${args}"
         ]
       }
     }


### PR DESCRIPTION
## Problem
Husky.Net printed a warning like `custom variable 'args[0]' not found` during `commit-msg`, and the commit message linter task was being skipped.

## Fix
Update the Husky.Net task config to use the built-in `${args}` variable (per Husky.Net schema) and pass it correctly to `bash -c` so the commit message file path is available as `$1`.

## Verification
- `dotnet husky run --group commit-msg --args /tmp/husky-msg.txt` succeeds for a valid Conventional Commit message
- The same command fails with an invalid message, confirming the task is actually executing
