### PR TITLE
feat(workflow): add view GitHub PR skill

### DIFF
--- a/.github/gh-cli-instructions.md
+++ b/.github/gh-cli-instructions.md
@@ -4,13 +4,18 @@
 
 GitHub CLI (`gh`) may trigger interactive pagers that block agent execution. **Always disable the pager** when running `gh` commands.
 
-## Required Pattern: Always Set PAGER
+## Required Pattern: Always Disable Paging
 
 **Use this pattern for EVERY `gh` command:**
 
 ```bash
-PAGER=cat gh [command] [options]
+GH_PAGER=cat GH_FORCE_TTY=false gh [command] [options]
 ```
+
+Why `GH_PAGER`?
+
+- `GH_PAGER` is `gh`’s own pager override (most reliable way to prevent `gh` from launching `less`).
+- `PAGER` is a general-purpose pager variable used by many tools; it can still be useful, but it’s easier to miss and can affect unrelated commands.
 
 Alternatively, set it once at the beginning of your session:
 
@@ -30,7 +35,7 @@ export GH_FORCE_TTY=false
 
 ```bash
 # Safe non-interactive issue creation
-echo "Automated issue body" | PAGER=cat GH_FORCE_TTY=false gh issue create --title "Automated" --body-file -
+echo "Automated issue body" | GH_PAGER=cat GH_FORCE_TTY=false gh issue create --title "Automated" --body-file -
 ```
 
 ## Common Commands - Correct Usage
@@ -39,10 +44,10 @@ echo "Automated issue body" | PAGER=cat GH_FORCE_TTY=false gh issue create --tit
 
 ```bash
 # List pull requests
-PAGER=cat gh pr list --json number,title,state,author
+GH_PAGER=cat GH_FORCE_TTY=false gh pr list --json number,title,state,author
 
 # View pull request details
-PAGER=cat gh pr view 123 --json number,title,body,state,commits,reviews
+GH_PAGER=cat GH_FORCE_TTY=false gh pr view 123 --json number,title,body,state,commits,reviews
 
 # Create pull request (preferred: repo wrapper scripts)
 # CRITICAL: Show the preview output in chat BEFORE creating/merging a PR.
@@ -56,26 +61,26 @@ scripts/pr-github.sh preview --fill
 scripts/pr-github.sh create --fill
 
 # Manual fallback (only if wrapper scripts are unavailable)
-PAGER=cat gh pr create --title "Title" --body "Description" --base main --head feature-branch
+GH_PAGER=cat GH_FORCE_TTY=false gh pr create --title "Title" --body "Description" --base main --head feature-branch
 
 # Check pull request status
-PAGER=cat gh pr status --json number,title,state
+GH_PAGER=cat GH_FORCE_TTY=false gh pr status --json number,title,state
 ```
 
 ### Issues
 
 ```bash
 # List issues
-PAGER=cat gh issue list --json number,title,state,author
+GH_PAGER=cat GH_FORCE_TTY=false gh issue list --json number,title,state,author
 
 # View issue details
-PAGER=cat gh issue view 123 --json number,title,body,state,comments
+GH_PAGER=cat GH_FORCE_TTY=false gh issue view 123 --json number,title,body,state,comments
 
 # Create issue
-PAGER=cat gh issue create --title "Title" --body "Description"
+GH_PAGER=cat GH_FORCE_TTY=false gh issue create --title "Title" --body "Description"
 
 # Close issue
-PAGER=cat gh issue close 123
+GH_PAGER=cat GH_FORCE_TTY=false gh issue close 123
 ```
 
 ### Repository Information

--- a/.github/skills/view-pr-github/SKILL.md
+++ b/.github/skills/view-pr-github/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: view-pr-github
+description: View GitHub PR status/details safely (non-interactive) using gh.
+compatibility: Requires GitHub CLI (gh) authenticated, plus network access.
+---
+
+# View PR (GitHub)
+
+## Purpose
+Read pull request status/details from GitHub without triggering an interactive pager.
+
+Use this skill for **read-only PR inspection** (status, checks, reviewers, files, body). For creating/merging PRs, prefer the repo wrapper scripts (see the `create-pr-github` skill).
+
+## Hard Rules
+### Must
+- Use a **non-interactive pager** for every `gh` call:
+  - Prefer `GH_PAGER=cat` (gh-specific, overrides gh’s internal pager logic)
+  - Also set `GH_FORCE_TTY=false` to reduce TTY-driven behavior
+- Prefer structured output (`--json`) and keep output small with `--jq` when practical.
+
+### Must Not
+- Run plain `gh ...` without `GH_PAGER=cat` (it may open `less` and block).
+- Change global GitHub CLI config (no `gh config set ...`).
+
+## Patterns
+
+### Minimal Safe Prefix
+Use this prefix for every command:
+
+```bash
+GH_PAGER=cat GH_FORCE_TTY=false gh ...
+```
+
+### 1) View PR Summary (safe JSON)
+
+```bash
+GH_PAGER=cat GH_FORCE_TTY=false gh pr view <pr-number> \
+  --json number,title,state,isDraft,url,mergeStateStatus,reviewDecision
+```
+
+### 2) View Checks (success/fail)
+
+```bash
+GH_PAGER=cat GH_FORCE_TTY=false gh pr view <pr-number> \
+  --json statusCheckRollup \
+  --jq '.statusCheckRollup[] | {name, status, conclusion}'
+```
+
+### 3) View Reviews / Review Requests
+
+```bash
+GH_PAGER=cat GH_FORCE_TTY=false gh pr view <pr-number> \
+  --json latestReviews,reviewRequests \
+  --jq '{latestReviews: [.latestReviews[] | {author: .author.login, state, submittedAt}], reviewRequests: [.reviewRequests[].login]}'
+```
+
+### 4) View Changed Files (names only)
+
+```bash
+GH_PAGER=cat GH_FORCE_TTY=false gh pr view <pr-number> --json files \
+  --jq '.files[].path'
+```
+
+### 5) View PR Body (for review)
+
+```bash
+GH_PAGER=cat GH_FORCE_TTY=false gh pr view <pr-number> --json body --jq '.body'
+```
+
+## When To Prefer Wrapper Scripts
+- If you are about to **create** or **merge** a PR: use `scripts/pr-github.sh preview/create/create-and-merge`.
+- If you just need to **inspect** PR state/checks/reviews: use this skill’s `gh` patterns.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -70,6 +70,7 @@ Format:
 | `generate-demo-artifacts` | Generate the comprehensive demo markdown artifact from the current codebase. |
 | `run-uat` | Run User Acceptance Testing by creating a PR with rendered markdown on GitHub or Azure DevOps. |
 | `simulate-uat` | Simulate the UAT workflow (create PR, comment, poll) on GitHub or Azure DevOps using a minimal test artifact and simulated fixes. |
+| `view-pr-github` | View a GitHub PR safely (non-interactive) using gh with pager disabled. |
 | `watch-uat-github-pr` | Watch a GitHub UAT PR for maintainer feedback or approval by polling comments until approved/passed. |
 | `watch-uat-azdo-pr` | Watch an Azure DevOps UAT PR for maintainer feedback or approval by polling threads and reviewer votes until approved/passed. |
 


### PR DESCRIPTION
## Problem
Even with existing guidance, `gh` has repeatedly entered interactive pager mode (e.g., `less`) during agent runs, blocking execution.

## Change
- Add a dedicated `view-pr-github` skill that standardizes safe, non-interactive `gh` commands using `GH_PAGER=cat GH_FORCE_TTY=false`.
- Update workflow docs to list the new skill.
- Clarify the GH CLI guidance to explain why `GH_PAGER` is preferred over `PAGER` for `gh`.

## Notes
This is intentionally read-only guidance; PR creation/merge continues to prefer the repo wrapper scripts.
