### PR TITLE
docs(workflow): test PR created without wrappers

### DIFF
--- a/issues/terminal-tool-output-truncation.md
+++ b/issues/terminal-tool-output-truncation.md
@@ -1,0 +1,9 @@
+# Terminal Tool Output Truncation
+
+Sometimes the VS Code chat terminal tool captures only part of a command’s output (even when the command succeeds). This can make wrapper scripts *look* unreliable when the underlying operation completed.
+
+## Practical Guidance
+
+- Prefer small, single-purpose terminal invocations over long chained one-liners.
+- Verify outcomes via GitHub data (e.g., PR exists / state / URL) rather than relying only on captured stdout.
+- If a GitHub chat tool exists for the data you need, prefer it for inspection.


### PR DESCRIPTION
## Problem
We observed that VS Code’s chat terminal tool can return truncated stdout/stderr, which can make terminal-driven PR workflows appear unreliable even when the underlying command succeeded.

## Change
Add a short note documenting terminal output truncation and practical verification guidance.

## Verification
- Created a new branch and pushed the change.
- Next step is opening a PR and verifying its existence/state via GitHub data (URL/state).
