### PR TITLE
docs(workflow): prefer GitHub tools over gh

### DIFF
--- a/.github/gh-cli-instructions.md
+++ b/.github/gh-cli-instructions.md
@@ -1,5 +1,9 @@
 # GitHub CLI Usage Instructions for Agents
 
+Preferred: use GitHub chat tools for GitHub PR/issue inspection and management.
+
+Use `gh` only as a fallback when the required operation is not available via chat tools or when a maintainer explicitly requests CLI reproduction steps.
+
 ## Critical: Prevent Interactive Mode
 
 GitHub CLI (`gh`) may trigger interactive pagers that block agent execution. **Always disable the pager** when running `gh` commands.
@@ -39,6 +43,18 @@ echo "Automated issue body" | GH_PAGER=cat GH_FORCE_TTY=false gh issue create --
 ```
 
 ## Common Commands - Correct Usage
+
+## Prefer GitHub Chat Tools (When Available)
+
+When you are operating inside VS Code Copilot chat and a GitHub tool exists for the task, prefer it.
+
+Examples (non-exhaustive):
+- PR details: get pull request details tool
+- PR files: list changed files tool
+- PR reviews / review comments: reviews + review comments tools
+- PR status checks: PR status tool
+
+Only use the `gh` examples below if the tool surface is missing what you need.
 
 ### Pull Requests
 

--- a/.github/skills/create-pr-github/SKILL.md
+++ b/.github/skills/create-pr-github/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-pr-github
-description: Create and (optionally) merge a GitHub pull request using gh, following the repo policy to use rebase and merge for a linear history.
-compatibility: Requires git and GitHub CLI (gh) authenticated, plus network access.
+description: Create and (optionally) merge a GitHub pull request (prefer GitHub chat tools; gh/wrappers are fallback), following the repo policy to use rebase and merge for a linear history.
+compatibility: Preferred: GitHub chat tools configured for the repo. Fallback: git + GitHub CLI (gh) authenticated, plus network access.
 ---
 
 # Create PR (GitHub)
@@ -9,7 +9,7 @@ compatibility: Requires git and GitHub CLI (gh) authenticated, plus network acce
 ## Purpose
 Create a GitHub pull request in a consistent, policy-compliant way, and include the repo’s preferred merge method guidance (rebase and merge).
 
-This skill prefers using the repo wrapper script `scripts/pr-github.sh` to minimize Maintainer approval interruptions (single terminal invocation).
+This skill prefers using GitHub chat tools because they can be permanently allowed in VS Code and avoid terminal pager/editor issues. If chat tools are unavailable (or repo context is unknown), fall back to the repo wrapper script `scripts/pr-github.sh`.
 
 ## Hard Rules
 ### Must
@@ -67,6 +67,14 @@ git push -u origin HEAD
 ```
 
 ### 3. Create the PR
+#### Preferred: GitHub chat tools
+Use the GitHub PR creation tool with an explicit title + body (same template as above).
+
+Notes:
+- This requires repo context (`owner` + `repo`) and your pushed branch name.
+- If you do not know `owner`/`repo` reliably, use the wrapper fallback below.
+
+#### Fallback: `gh` CLI
 ```bash
 PAGER=cat gh pr create \
   --base main \
@@ -78,6 +86,10 @@ PAGER=cat gh pr create \
 ### 4. Merge (Only When Explicitly Requested)
 This repository requires **rebase and merge**.
 
+#### Preferred: GitHub chat tools
+Use the GitHub PR merge tool with `merge_method=rebase`.
+
+#### Fallback: `gh` CLI
 ```bash
 PAGER=cat gh pr merge <pr-number> --rebase --delete-branch
 ```

--- a/.github/skills/run-uat/SKILL.md
+++ b/.github/skills/run-uat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-uat
 description: Run User Acceptance Testing by creating a PR with rendered markdown on GitHub or Azure DevOps. Use when validating markdown rendering in real platforms.
-compatibility: Requires git, GitHub CLI (gh) and/or Azure CLI (az) + azure-devops extension, plus network access.
+compatibility: Requires git. GitHub UAT uses repo scripts which require GitHub CLI (gh) authenticated. Azure DevOps UAT requires Azure CLI (az) + azure-devops extension. Network access required.
 ---
 
 # Run UAT
@@ -23,8 +23,10 @@ Execute end-to-end User Acceptance Testing by posting the comprehensive demo art
 - Modify any source code during UAT.
 
 ## Pre-requisites
-- GitHub CLI (`gh`) authenticated for GitHub UAT.
-- Azure CLI (`az`) with DevOps extension for Azure DevOps UAT.
+- GitHub UAT: repo scripts require GitHub CLI (`gh`) authenticated.
+- Azure DevOps UAT: Azure CLI (`az`) with DevOps extension.
+
+For read-only inspection of PR state/comments during UAT (outside the scripts), prefer GitHub chat tools when available.
 
 ## Actions
 

--- a/.github/skills/simulate-uat/SKILL.md
+++ b/.github/skills/simulate-uat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: simulate-uat
 description: Simulate the UAT workflow (create PR, comment, poll) on GitHub or Azure DevOps using a minimal test artifact and simulated fixes.
-compatibility: Requires git, GitHub CLI (gh) and/or Azure CLI (az) + azure-devops extension, plus network access.
+compatibility: Requires git. GitHub simulation uses repo scripts which require GitHub CLI (gh) authenticated. Azure DevOps simulation requires Azure CLI (az) + azure-devops extension. Network access required.
 ---
 
 # Simulate UAT

--- a/.github/skills/view-pr-github/SKILL.md
+++ b/.github/skills/view-pr-github/SKILL.md
@@ -1,22 +1,26 @@
 ---
 name: view-pr-github
-description: View GitHub PR status/details safely (non-interactive) using gh.
-compatibility: Requires GitHub CLI (gh) authenticated, plus network access.
+description: View GitHub PR status/details (prefer GitHub chat tools; gh is fallback).
+compatibility: Preferred: GitHub chat tools configured for the repo. Fallback: GitHub CLI (gh) authenticated, plus network access.
 ---
 
 # View PR (GitHub)
 
 ## Purpose
-Read pull request status/details from GitHub without triggering an interactive pager.
+Read pull request status/details from GitHub.
+
+Preferred: use GitHub chat tools (stable, structured, avoids pager/editor pitfalls).
+Fallback: use non-interactive `gh` patterns.
 
 Use this skill for **read-only PR inspection** (status, checks, reviewers, files, body). For creating/merging PRs, prefer the repo wrapper scripts (see the `create-pr-github` skill).
 
 ## Hard Rules
 ### Must
-- Use a **non-interactive pager** for every `gh` call:
+- Prefer GitHub chat tools when they can answer the question.
+- If using `gh`, use a **non-interactive pager** for every `gh` call:
   - Prefer `GH_PAGER=cat` (gh-specific, overrides gh’s internal pager logic)
   - Also set `GH_FORCE_TTY=false` to reduce TTY-driven behavior
-- Prefer structured output (`--json`) and keep output small with `--jq` when practical.
+  - Prefer structured output (`--json`) and keep output small with `--jq` when practical.
 
 ### Must Not
 - Run plain `gh ...` without `GH_PAGER=cat` (it may open `less` and block).
@@ -24,7 +28,17 @@ Use this skill for **read-only PR inspection** (status, checks, reviewers, files
 
 ## Patterns
 
-### Minimal Safe Prefix
+### Preferred: GitHub Chat Tools
+Use chat tools for:
+- PR details/metadata
+- changed files
+- reviews
+- status checks
+- conversation comments and inline review comments
+
+If a tool exists that directly answers the question, use it. If not, use the `gh` fallback patterns below.
+
+### Fallback: Minimal Safe Prefix
 Use this prefix for every command:
 
 ```bash

--- a/.github/skills/watch-uat-github-pr/SKILL.md
+++ b/.github/skills/watch-uat-github-pr/SKILL.md
@@ -1,15 +1,18 @@
 ---
 name: watch-uat-github-pr
 description: Watch a GitHub UAT PR for maintainer feedback or approval by polling comments until approved/passed.
-compatibility: Requires GitHub CLI (gh) authenticated, plus network access.
+compatibility: Preferred: GitHub chat tools configured for the repo. Fallback: repo wrapper scripts (requires GitHub CLI (gh) authenticated), plus network access.
 ---
 
 # Watch UAT PR (GitHub)
 
 ## Purpose
-UAT comment polling is historically brittle. This skill standardizes the watch loop so the agent can reliably wait for Maintainer feedback/approval using a single stable command.
+UAT comment polling is historically brittle. This skill standardizes the watch loop so the agent can reliably wait for Maintainer feedback/approval.
 
-This skill uses the repo wrapper script `scripts/uat-watch-github.sh`, which repeatedly calls `scripts/uat-github.sh poll` until:
+Preferred: use GitHub chat tools to poll PR state + comments (avoids terminal output/pager issues).
+Fallback: use the stable wrapper command.
+
+Fallback path uses the repo wrapper script `scripts/uat-watch-github.sh`, which repeatedly calls `scripts/uat-github.sh poll` until:
 - approval keywords are detected, or
 - the PR is closed/merged, or
 - a timeout is reached.
@@ -25,6 +28,15 @@ This skill uses the repo wrapper script `scripts/uat-watch-github.sh`, which rep
 - Run many ad-hoc `gh` commands; prefer the wrapper.
 
 ## Actions
+
+### Preferred: Poll using GitHub chat tools
+Repeatedly:
+- Fetch PR details (state)
+- Fetch PR conversation comments
+- Stop and report if the PR is closed/merged
+- Treat any detected approval (`approved|passed|accept|lgtm`) as UAT passed
+
+### Fallback: One-command wrapper
 
 ### 1. Watch the PR
 ```bash

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -74,13 +74,13 @@ Format:
 | Skill Name | Description |
 | :--- | :--- |
 | `create-agent-skill` | Create a new Agent Skill following project standards and templates. |
-| `create-pr-github` | Create and (optionally) merge a GitHub pull request using gh, following the repo policy to use rebase and merge for a linear history. |
+| `create-pr-github` | Create and (optionally) merge a GitHub pull request (prefer GitHub chat tools; gh/wrappers are fallback), following the repo policy to use rebase and merge for a linear history. |
 | `create-pr-azdo` | Create an Azure DevOps pull request using az devops tooling; include the repo’s linear-history merge preference and ask the Maintainer if merge options differ. |
 | `git-rebase-main` | Safely rebase the current feature branch on top of the latest origin/main. |
 | `generate-demo-artifacts` | Generate the comprehensive demo markdown artifact from the current codebase. |
 | `run-uat` | Run User Acceptance Testing by creating a PR with rendered markdown on GitHub or Azure DevOps. |
 | `simulate-uat` | Simulate the UAT workflow (create PR, comment, poll) on GitHub or Azure DevOps using a minimal test artifact and simulated fixes. |
-| `view-pr-github` | View a GitHub PR safely (non-interactive) using gh with pager disabled. |
+| `view-pr-github` | View a GitHub PR (prefer GitHub chat tools; gh is fallback with pager disabled). |
 | `watch-uat-github-pr` | Watch a GitHub UAT PR for maintainer feedback or approval by polling comments until approved/passed. |
 | `watch-uat-azdo-pr` | Watch an Azure DevOps UAT PR for maintainer feedback or approval by polling threads and reviewer votes until approved/passed. |
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -95,5 +95,5 @@ The goal of this tool is to help DevOps and infrastructure teams easily review T
 - GitHub branch protection rules (requiring status checks) require GitHub Pro for private repositories
 - Until the repository is made public, PRs CAN be merged before the "PR Validation" workflow completes
 - **CRITICAL**: Agents and maintainers must manually verify "PR Validation" shows ✅ success before merging
-- The Release Manager agent enforces this requirement by monitoring PR checks with `gh pr checks --watch`
+- The Release Manager agent enforces this requirement by monitoring PR status checks (prefer GitHub chat tools; `gh pr checks --watch` is a fallback)
 - Once the repository is public, configure branch protection to require the "PR Validation" workflow as a required status check

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -172,7 +172,10 @@ scripts/uat-azdo.sh cleanup <pr-id>
 
 **Manual fallbacks (only for debugging)**:
 
-**GitHub**:
+**GitHub (preferred in VS Code chat)**:
+- Use GitHub chat tools to fetch PR conversation comments and review comments.
+
+**GitHub (CLI fallback)**:
 ```bash
 PAGER=cat gh pr view <pr-number> --comments
 ```


### PR DESCRIPTION
## Problem
Workflow docs and skills still treat `gh` as the primary path for PR inspection/management, which increases terminal approval friction and can be brittle due to pager/editor behavior.

## Change
Update PR-related skills and workflow docs to prefer GitHub chat tools when available, and clearly position `gh` + wrapper scripts as fallback (keeping non-interactive `gh` guidance for those cases).

## Verification
- `dotnet test` (301 passed)
- Husky hooks (`dotnet format` + build) ran successfully on commit