### PR TITLE
docs(agents): prefer GitHub tools over gh

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -87,7 +87,7 @@ Before starting, familiarize yourself with:
 - [docs/architecture.md](../../docs/architecture.md) - Existing architecture overview
 - Existing ADRs in `docs/` (files matching `adr-*.md`) - Previous architecture decisions
 - [docs/agents.md](../../docs/agents.md) - Workflow overview and artifact formats
-- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI usage if needed
+- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI fallback guidance (only if a chat tool is missing)
 - Relevant source code in `src/` to understand current patterns
 
 ## Conversation Approach

--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -89,7 +89,7 @@ Before starting, familiarize yourself with:
 - [docs/spec.md](../../docs/spec.md) - Project specification and coding standards
 - [docs/commenting-guidelines.md](../../docs/commenting-guidelines.md) - **Code documentation requirements**
 - [.github/copilot-instructions.md](../copilot-instructions.md) - Coding guidelines
-- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI usage if needed
+- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI fallback guidance (only if a chat tool is missing)
 - [docs/testing-strategy.md](../../docs/testing-strategy.md) - Testing conventions
 - [Scriban Language Reference](https://github.com/scriban/scriban/blob/master/doc/language.md) - For template-related work
 - The implementation in `src/` and `tests/`

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -87,7 +87,7 @@ Before starting, familiarize yourself with:
 - [docs/spec.md](../../docs/spec.md) - Project specification and coding standards
 - [docs/commenting-guidelines.md](../../docs/commenting-guidelines.md) - **Code documentation requirements**
 - [.github/copilot-instructions.md](../copilot-instructions.md) - Coding guidelines
-- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - **GitHub CLI usage (when checking failed workflows)**
+- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - **GitHub CLI fallback guidance (when checking failed workflows)**
 - [Scriban Language Reference](https://github.com/scriban/scriban/blob/master/doc/language.md) - For template-related work
 - Existing source code in `src/` and tests in `tests/`
 
@@ -243,6 +243,10 @@ docker run --rm -v $(pwd):/data tfplan2md:local /data/plan.json
 
 When fixing PR/CI failures, check workflow logs:
 
+Preferred in VS Code chat:
+- Use GitHub chat tools to fetch PR status checks.
+- If you do not have repo context (owner/repo) or a tool is missing, fall back to `gh`.
+
 ```bash
 # List recent workflow runs (non-blocking)
 PAGER=cat gh run list --limit 5
@@ -250,11 +254,11 @@ PAGER=cat gh run list --limit 5
 # View specific failed run
 PAGER=cat gh run view <run-id> --log-failed
 
-# Check PR validation status
+# PR validation status (fallback)
 PAGER=cat gh pr checks <pr-number>
 ```
 
-**Important**: Always use `PAGER=cat` prefix with `gh` commands to prevent interactive pagers from blocking. See [.github/gh-cli-instructions.md](../gh-cli-instructions.md) for details.
+**Important**: If you run `gh`, always use `PAGER=cat` (or `GH_PAGER=cat`) to prevent interactive pagers from blocking. See [.github/gh-cli-instructions.md](../gh-cli-instructions.md) for details.
 
 ## Definition of Done
 

--- a/.github/agents/issue-analyst.agent.md
+++ b/.github/agents/issue-analyst.agent.md
@@ -138,7 +138,10 @@ Collect relevant data:
 
 **Commands to use:**
 ```bash
-# Check workflow runs (non-blocking)
+# Preferred in VS Code chat:
+# - Use GitHub chat tools to inspect PR status checks, PR details, and PR comments.
+#
+# Fallback: check workflow runs via gh (non-blocking)
 PAGER=cat gh run list --limit 5 --json conclusion,status,name,createdAt
 
 # View specific workflow run (non-blocking)
@@ -157,7 +160,7 @@ dotnet test --verbosity normal
 # Use the 'problems' tool to see diagnostics
 ```
 
-**Important:** For instructions on how to use the GitHub CLI (`gh`) in automated agents, refer to the [.github/gh-cli-instructions.md](../gh-cli-instructions.md) file. Always use `PAGER=cat` prefix to prevent interactive pagers from blocking execution.
+**Important:** Prefer GitHub chat tools when available. If you must use `gh`, follow [.github/gh-cli-instructions.md](../gh-cli-instructions.md) and always disable paging (`PAGER=cat` / `GH_PAGER=cat`) to prevent blocking.
 
 ### Step 3: Analyze the Issue
 

--- a/.github/agents/quality-engineer.agent.md
+++ b/.github/agents/quality-engineer.agent.md
@@ -72,7 +72,7 @@ Before starting, familiarize yourself with:
 - The Architecture document in `docs/features/<feature-name>/architecture.md` (if exists)
 - [docs/testing-strategy.md](../../docs/testing-strategy.md) - Project testing conventions and infrastructure
 - [docs/agents.md](../../docs/agents.md) - Workflow overview and artifact formats
-- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI usage if needed
+- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI fallback guidance (only if a chat tool is missing)
 - Existing tests in `tests/` to understand patterns and conventions
 
 ## Project Testing Conventions

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -91,13 +91,13 @@ This project uses:
 - Do NOT edit `CHANGELOG.md` manually - Versionize generates it automatically
 - Version bumping is handled by Versionize based on conventional commits
 - The CI pipeline builds and publishes the Docker image
-- **CRITICAL**: For instructions on how to use the GitHub CLI (`gh`) in automated agents, refer to the [.github/gh-cli-instructions.md](../gh-cli-instructions.md) file. Always use `PAGER=cat` prefix or export `GH_PAGER=cat` to prevent interactive pagers from blocking execution
+- **CRITICAL**: Prefer GitHub chat tools for PR inspection in VS Code chat. Use `gh` only as a fallback; when you do, follow [.github/gh-cli-instructions.md](../gh-cli-instructions.md) and always disable paging to prevent blocking execution.
 
 ## Pre-Release Checklist
 
 Before releasing, verify:
 
-0. **Prevent gh CLI blocking** (run once per session):
+0. **If using gh: prevent CLI blocking** (run once per session):
    ```bash
    export GH_PAGER=cat
    export GH_FORCE_TTY=false
@@ -155,6 +155,11 @@ Before releasing, verify:
    - Provide the PR link to the maintainer
 
 4. **Wait for PR Validation** - Monitor PR checks and wait for completion:
+   Preferred in VS Code chat:
+   - Use GitHub chat tools to fetch PR status checks.
+   - Re-check until all required checks show success.
+
+   Fallback (terminal):
    ```bash
    PAGER=cat gh pr checks --watch
    ```

--- a/.github/agents/requirements-engineer.agent.md
+++ b/.github/agents/requirements-engineer.agent.md
@@ -83,7 +83,7 @@ Before starting, familiarize yourself with:
 - [docs/spec.md](../../docs/spec.md) - Project specification and goals
 - [docs/features.md](../../docs/features.md) and feature descriptions in `docs/features/` - Existing features
 - [docs/agents.md](../../docs/agents.md) - Workflow overview and artifact formats
-- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI usage if needed
+- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI fallback guidance (only if a chat tool is missing)
 - [README.md](../../README.md) - Project overview
 
 ## Conversation Approach

--- a/.github/agents/task-planner.agent.md
+++ b/.github/agents/task-planner.agent.md
@@ -67,7 +67,7 @@ Before starting, familiarize yourself with:
 - The Architecture document in `docs/features/<feature-name>/architecture.md` (if exists)
 - [docs/agents.md](../../docs/agents.md) - Workflow overview and artifact formats
 - [docs/spec.md](../../docs/spec.md) - Project goals and constraints
-- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI usage if needed
+- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI fallback guidance (only if a chat tool is missing)
 
 ## Conversation Approach
 

--- a/.github/agents/technical-writer.agent.md
+++ b/.github/agents/technical-writer.agent.md
@@ -72,7 +72,7 @@ Before starting, familiarize yourself with:
 - [docs/spec.md](../../docs/spec.md) - Project specification
 - [docs/features.md](../../docs/features.md) - Feature descriptions
 - [docs/agents.md](../../docs/agents.md) - Workflow overview and artifact formats
-- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI usage if needed
+- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - GitHub CLI fallback guidance (only if a chat tool is missing)
 - Existing documentation in `docs/`
 
 ## Documentation Standards

--- a/.github/agents/uat-tester.agent.md
+++ b/.github/agents/uat-tester.agent.md
@@ -149,7 +149,7 @@ When not specified by the user, use these defaults:
 # Check current branch (must not be main)
 git branch --show-current
 
-# Check GitHub CLI authentication
+# Check GitHub CLI authentication (required for repo UAT scripts)
 gh auth status
 
 # Check Azure CLI authentication
@@ -176,8 +176,13 @@ Before creating a new UAT branch, check if one already exists:
 ```bash
 # Check for existing UAT branches
 git branch -a | grep "uat/" | head -10
+```
 
-# Check for open UAT PRs on GitHub
+Preferred in VS Code chat:
+- Use GitHub chat tools to find open UAT PRs (search PRs with `uat` in title, and/or list open PRs and filter by head branch).
+
+Fallback (terminal):
+```bash
 PAGER=cat gh pr list --state open --json number,title,headRefName | grep -i uat || echo "No open UAT PRs"
 ```
 

--- a/.github/agents/workflow-engineer.agent.md
+++ b/.github/agents/workflow-engineer.agent.md
@@ -74,7 +74,7 @@ Before making changes, familiarize yourself with:
 - [docs/agents.md](../../docs/agents.md) - The complete workflow documentation (your primary reference)
 - [docs/ai-model-reference.md](../../docs/ai-model-reference.md) - **Model performance benchmarks, availability, and pricing data**
 - [.github/copilot-instructions.md](../copilot-instructions.md) - Project-wide Copilot instructions including tool naming conventions
-- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - **GitHub CLI usage for automated agents**
+- [.github/gh-cli-instructions.md](../gh-cli-instructions.md) - **GitHub CLI fallback guidance for automated agents**
 - All existing agents in `.github/agents/*.agent.md` - Current agent definitions
 - [docs/spec.md](../../docs/spec.md) - Project specification
 


### PR DESCRIPTION
## Problem
Several agent definitions still recommend `gh` commands for PR inspection (checks, status, PR discovery) even when GitHub chat tools can provide the same info with fewer terminal approvals and less pager/editor risk.

## Change
Update `.github/agents/*.agent.md` to prefer GitHub chat tools for PR inspection where available, and treat `gh` as an explicit fallback (keeping `gh` guidance for Actions/workflow operations the tools don’t cover).

## Verification
- `dotnet test` (301 passed)
- Husky hooks (`dotnet format` + build) ran successfully on commit