### PR TITLE
fix(workflow): add quotes to Retrospective agent handoff

### DIFF
--- a/.github/agents/retrospective.agent.md
+++ b/.github/agents/retrospective.agent.md
@@ -6,7 +6,7 @@ model: Gemini 3 Pro (Preview)
 tools: ['readFile', 'listDirectory', 'fileSearch', 'edit', 'github/*', 'todo']
 handoffs:
   - label: Update Workflow
-    agent: Workflow Engineer
+    agent: "Workflow Engineer"
     prompt: I have identified some workflow improvements in the retrospective. Please help me implement them.
     send: false
 ---


### PR DESCRIPTION
## Problem
Retrospective agent handoff definition uses inconsistent quoting (`agent: Workflow Engineer` without quotes) while all other agents use quotes (`agent: "Agent Name"`).

## Change
Added quotes to the Retrospective agent handoff `agent` field for consistency with all other agent definitions.

## Verification
- Pre-commit hooks (`dotnet format` + build) passed
- Single-line change maintains correct YAML syntax