### PR TITLE
feat(workflow): add Release Manager → Retrospective handoff

### DIFF
--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -9,6 +9,10 @@ handoffs:
     agent: "Developer"
     prompt: The PR build validation or release pipeline failed. Please investigate and fix the issues.
     send: false
+  - label: Conduct Retrospective
+    agent: "Retrospective"
+    prompt: The release is complete. Please conduct a retrospective to identify workflow improvements.
+    send: false
 ---
 
 # Release Manager Agent


### PR DESCRIPTION
## Problem
Release Manager agent does not have an explicit handoff to Retrospective agent after successful releases, as identified in the [retrospective follow-up tracking](https://github.com/oocx/tfplan2md/blob/main/docs/features/consistent-value-formatting/retrospective.md#progress-update-as-of-2025-12-25).

## Change
Added "Conduct Retrospective" handoff button to Release Manager agent that prompts the Retrospective agent to analyze the completed release cycle.

## Verification
- Pre-commit hooks (`dotnet format` + build) passed
- Handoff follows the same structure as other agent handoffs
- Agent name "Retrospective" matches existing agent definition