### PR TITLE
feat(workflow): add role boundaries and handoff/status templates

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -54,6 +54,7 @@ Transform a Feature Specification into a clear technical design with documented 
 ### 🚫 Never Do
 - Write or modify implementation code (.cs, .csproj, test files, templates, etc.)
 - Edit any files except markdown documentation (.md files)
+- Create or edit tasks.md (Task Planner owns this deliverable)
 - Make implementation decisions that belong to the Developer
 - Create ADRs without considering multiple options
 - Design without reviewing existing codebase patterns
@@ -78,6 +79,17 @@ Todo lists:
 - **Option 1:** <clear next action>
 - **Option 2:** <clear alternative>
 **Recommendation:** Option <n>, because <short reason>.
+
+### Handoff Template
+
+When handing off to another agent, include:
+```
+**Handoff Summary:**
+- ✅ Completed: <what was done>
+- 📄 Artifacts: <list of created/updated files>
+- ⏭️ Next Step: <specific next action for receiving agent>
+- 🚦 Status: Ready / Blocked (if blocked, state reason)
+```
 
 ## Context to Read
 

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -40,6 +40,7 @@ Produce clean, well-tested code that meets all acceptance criteria and follows p
 - Use `_camelCase` for private fields
 - Update `examples/comprehensive-demo/plan.json` when features have visible impact on generated markdown
 - Follow [docs/report-style-guide.md](../../docs/report-style-guide.md) for all markdown rendering code
+- Provide explicit status at end of every turn using the Status Template (see Response Style section)
 
 ### ⚠️ Ask First
 - Changes that affect architecture decisions
@@ -77,6 +78,33 @@ Todo lists:
 - **Option 1:** <clear next action>
 - **Option 2:** <clear alternative>
 **Recommendation:** Option <n>, because <short reason>.
+
+### Status Template
+
+At the end of every turn, provide:
+```
+**Status:** Done / In Progress / Blocked
+
+**What Changed:**
+- <specific changes made this turn>
+
+**What's Next:**
+- <next steps or what needs to happen>
+
+**What I Need:**
+- <any blockers or questions for Maintainer, or "Nothing" if unblocked>
+```
+
+### Handoff Template
+
+When handing off to another agent, include:
+```
+**Handoff Summary:**
+- ✅ Completed: <what was done>
+- 📄 Artifacts: <list of created/updated files>
+- ⏭️ Next Step: <specific next action for receiving agent>
+- 🚦 Status: Ready / Blocked (if blocked, state reason)
+```
 
 ## Context to Read
 

--- a/.github/agents/task-planner.agent.md
+++ b/.github/agents/task-planner.agent.md
@@ -27,6 +27,7 @@ Break down the feature into clear, prioritized work items with well-defined acce
 - Prioritize tasks based on dependencies and risk
 - Ensure each task maps back to the Feature Specification
 - Consider implementation order (foundational work first)
+- Create and own tasks.md (this is your exclusive deliverable)
 - Commit tasks document when approved
 
 ### ⚠️ Ask First
@@ -59,6 +60,17 @@ Todo lists:
 - **Option 1:** <clear next action>
 - **Option 2:** <clear alternative>
 **Recommendation:** Option <n>, because <short reason>.
+
+### Handoff Template
+
+When handing off to another agent, include:
+```
+**Handoff Summary:**
+- ✅ Completed: <what was done>
+- 📄 Artifacts: <list of created/updated files>
+- ⏭️ Next Step: <specific next action for receiving agent>
+- 🚦 Status: Ready / Blocked (if blocked, state reason)
+```
 
 ## Context to Read
 


### PR DESCRIPTION
## Problem
Three workflow issues identified in retrospective caused confusion and inefficiency:
1. **Role boundary confusion**: Architect created/edited tasks.md (Task Planner's deliverable)
2. **Unclear handoff messages**: Missing context about what's done/next/blocked
3. **Developer status updates missing**: Top Maintainer pain point - unclear "done vs pending" status

## Change
### 1. Role Boundary Enforcement
- **Architect**: Added "Never Do" rule preventing tasks.md creation/editing
- **Task Planner**: Clarified exclusive ownership of tasks.md in "Always Do"

### 2. Handoff Template (Architect, Task Planner, Developer)
Added standardized handoff template:
```
**Handoff Summary:**
- ✅ Completed: <what was done>
- 📄 Artifacts: <list of created/updated files>
- ⏭️ Next Step: <specific next action for receiving agent>
- 🚦 Status: Ready / Blocked (if blocked, state reason)
```

### 3. Status Template (Developer only)
Added required end-of-turn status template:
```
**Status:** Done / In Progress / Blocked

**What Changed:** <specific changes made>
**What's Next:** <next steps>
**What I Need:** <blockers or "Nothing">
```

## Verification
- Pre-commit hooks (`dotnet format` + build) passed
- 3 agents updated with consistent templates
- Templates enforce clarity identified in retrospective