### PR TITLE
docs(workflow): update retrospective tracking with completed PRs #111-114

### DIFF
--- a/docs/features/consistent-value-formatting/retrospective.md
+++ b/docs/features/consistent-value-formatting/retrospective.md
@@ -87,23 +87,23 @@ Use this section (with the same fields) in all retrospectives so trends are trac
 | UAT branch naming collisions | Standardize a high-uniqueness naming scheme, e.g., `<original-branch>-uat-<UTC timestamp>` (and keep `-vN` as a fallback). | Update UAT scripts to generate unique branch names by default and print them in the output. |
 | Retrospectives miss consistent, reproducible metrics | Provide the Retrospective agent a short “metrics recipe” with examples: how to compute lead time from git reflog / tags and how to estimate review/UAT loops from chat history + docs. | Update the Retrospective agent instructions to include a metrics section and a recommended method per metric (including fallbacks when branch history is squashed/rebased). |
 
-## Progress Update (As of 2025-12-25)
+## Progress Update (As of 2025-12-26)
 
 This section tracks follow-up implementation progress from this retrospective.
 
 | Item | Status | PRs / Notes |
 |---|---|---|
-| Reduce manual approvals via stable wrappers | ✅ Partial | GitHub PR wrapper added ([#87](https://github.com/oocx/tfplan2md/pull/87)); Azure DevOps PR wrapper added ([#88](https://github.com/oocx/tfplan2md/pull/88)); AzDO abandon cleanup added ([#89](https://github.com/oocx/tfplan2md/pull/89)); end-to-end UAT wrapper added ([#95](https://github.com/oocx/tfplan2md/pull/95)). |
-| Make PR feedback polling less brittle | ✅ Partial | UAT PR watch scripts/skills added ([#90](https://github.com/oocx/tfplan2md/pull/90)); GitHub UAT poll hardened to use JSON queries and filter agent comments ([#92](https://github.com/oocx/tfplan2md/pull/92)). |
+| Reduce manual approvals via stable wrappers | ✅ Done | GitHub PR wrapper ([#87](https://github.com/oocx/tfplan2md/pull/87)); Azure DevOps PR wrapper ([#88](https://github.com/oocx/tfplan2md/pull/88)); AzDO abandon cleanup ([#89](https://github.com/oocx/tfplan2md/pull/89)); end-to-end UAT wrapper ([#95](https://github.com/oocx/tfplan2md/pull/95)); GitHub tools preferred over gh CLI ([#108](https://github.com/oocx/tfplan2md/pull/108), [#109](https://github.com/oocx/tfplan2md/pull/109)). |
+| Make PR feedback polling less brittle | ✅ Done | UAT PR watch scripts/skills added ([#90](https://github.com/oocx/tfplan2md/pull/90)); GitHub UAT poll hardened to use JSON queries and filter agent comments ([#92](https://github.com/oocx/tfplan2md/pull/92)); GitHub tools preferred for PR inspection ([#108](https://github.com/oocx/tfplan2md/pull/108), [#109](https://github.com/oocx/tfplan2md/pull/109)). |
 | Reduce Maintainer “Allow” uncertainty | ✅ Done | Workflow now requires agents to post the **exact PR title + description** in chat (using the standard template) before running PR creation commands. This supersedes the earlier wrapper-based `preview` approach (see [#93](https://github.com/oocx/tfplan2md/pull/93) and [#96](https://github.com/oocx/tfplan2md/pull/96) for history). |
 | Skill authoring guidance (approval minimization) | ✅ Done | Added explicit guidance to prefer stable wrapper commands to reduce approvals ([#86](https://github.com/oocx/tfplan2md/pull/86)). |
 | UAT run/simulate skills foundation | ✅ Done | Initial UAT-related skills and scripts registered in workflow docs ([#85](https://github.com/oocx/tfplan2md/pull/85)). |
 | Standard metrics section in retrospectives | ✅ Done | Added/standardized metrics guidance in workflow docs/retrospective artifacts ([#84](https://github.com/oocx/tfplan2md/pull/84)). |
 | Guardrails against wrong UAT artifact | ✅ Partial | Added guardrails in UAT scripts and updated UAT guidance to prefer the UAT wrapper ([#95](https://github.com/oocx/tfplan2md/pull/95)). Canonical artifact enforcement still pending. |
-| Doc alignment gate in Code Review | ⏳ Not started | Still needs an explicit checklist gate covering spec/tasks/test plan alignment. |
-| Role boundaries + handoff/status templates | ⏳ Not started | Still needs enforcement in agent definitions. |
-| Wire report style guide into agents | ⏳ Not started | Still needs agent-doc references/requirements. |
-| Release-to-retro handoff consistency | ⏳ Not started | Still needs explicit Release Manager handoff expectations encoded. |
+| Doc alignment gate in Code Review | ✅ Done | Added documentation alignment checklist gate to Code Reviewer ([#113](https://github.com/oocx/tfplan2md/pull/113)). |
+| Role boundaries + handoff/status templates | ✅ Done | Enforced role boundaries (Architect/Task Planner), added handoff template, added Developer status template ([#114](https://github.com/oocx/tfplan2md/pull/114)). |
+| Wire report style guide into agents | ✅ Done | Added report style guide references to Requirements Engineer, Developer, Code Reviewer, Technical Writer, UAT Tester ([#112](https://github.com/oocx/tfplan2md/pull/112)). |
+| Release-to-retro handoff consistency | ✅ Done | Added Release Manager → Retrospective handoff button ([#111](https://github.com/oocx/tfplan2md/pull/111)). |
 
 ## Draft Notes
 

--- a/docs/roadmap-workflow-improvements-2025-q4.md
+++ b/docs/roadmap-workflow-improvements-2025-q4.md
@@ -25,6 +25,7 @@ This roadmap outlines a series of workflow improvements derived from the "Consis
 - ✅ Hardened GitHub UAT polling to use structured JSON and filter agent comments: ([#92](https://github.com/oocx/tfplan2md/pull/92))
 - ✅ Added `scripts/uat-run.sh` end-to-end wrapper (GitHub + AzDO orchestration): ([#95](https://github.com/oocx/tfplan2md/pull/95))
 - ✅ Added initial guardrails against wrong artifacts in UAT scripts (canonical artifact enforcement still pending): ([#95](https://github.com/oocx/tfplan2md/pull/95))
+- ✅ Migrated to tools-first approach: GitHub chat tools preferred over gh CLI for PR inspection/management ([#108](https://github.com/oocx/tfplan2md/pull/108), [#109](https://github.com/oocx/tfplan2md/pull/109))
 
 ## 2. 🤝 Agent Communication & Role Clarity
 
@@ -38,7 +39,9 @@ This roadmap outlines a series of workflow improvements derived from the "Consis
     *   Require explicit Developer status updates and `tasks.md` sync.
 
 **Progress**
-- ⏳ Not implemented yet (still planned)
+- ✅ Role boundaries enforced: Architect forbidden from creating/editing tasks.md, Task Planner owns tasks.md ([#114](https://github.com/oocx/tfplan2md/pull/114))
+- ✅ Handoff template added to Architect, Task Planner, Developer ([#114](https://github.com/oocx/tfplan2md/pull/114))
+- ✅ Developer status template added requiring explicit status + tasks.md sync ([#114](https://github.com/oocx/tfplan2md/pull/114))
 
 ## 3. 🛡️ Process Gates & Standards
 
@@ -56,9 +59,10 @@ This roadmap outlines a series of workflow improvements derived from the "Consis
 - ✅ Added skill design guidance to minimize Maintainer approvals (prefer stable wrapper commands): ([#86](https://github.com/oocx/tfplan2md/pull/86))
 - ✅ PR creation skills require agents to post the exact PR title + description in chat (using the standard template) before creating PRs (supersedes earlier "preview" approach).
 - ✅ Wrapper scripts require explicit `--title` and `--body`/`--body-file` (no heuristics like `--fill`).
-- ⏳ Doc alignment gate in Code Review not implemented yet
-- ⏳ Report style guide wiring into agent instructions not implemented yet
-- ⏳ Release Manager merge-method enforcement not implemented yet
+- ✅ Doc alignment gate added to Code Reviewer ([#113](https://github.com/oocx/tfplan2md/pull/113))
+- ✅ Report style guide wired into Requirements Engineer, Developer, Code Reviewer, Technical Writer, UAT Tester ([#112](https://github.com/oocx/tfplan2md/pull/112))
+- ✅ Release Manager → Retrospective handoff added ([#111](https://github.com/oocx/tfplan2md/pull/111))
+- ⏳ Release Manager merge-method enforcement not explicitly added yet (rebase policy exists in Release Manager Always Do section)
 
 ## 4. 📊 Metrics & Retrospectives
 


### PR DESCRIPTION
## Problem
The retrospective and roadmap tracking documents still showed 4 workflow improvement items as "⏳ Not started" even though they were completed via PRs #111-114.

## Changes
- Updated `docs/features/consistent-value-formatting/retrospective.md`:
  - Changed date from 2025-12-25 to 2025-12-26
  - Marked 4 items as ✅ Done with PR references:
    - Doc alignment gate in Code Review ([#113](https://github.com/oocx/tfplan2md/pull/113))
    - Role boundaries + handoff/status templates ([#114](https://github.com/oocx/tfplan2md/pull/114))
    - Wire report style guide into agents ([#112](https://github.com/oocx/tfplan2md/pull/112))
    - Release-to-retro handoff consistency ([#111](https://github.com/oocx/tfplan2md/pull/111))
  - Updated "Reduce manual approvals" and "Make PR feedback" to ✅ Done, added references to tools-first migration PRs #108-109

- Updated `docs/roadmap-workflow-improvements-2025-q4.md`:
  - Section 1: Added tools-first migration PR references (#108-109)
  - Section 2: Marked all Agent Communication items as ✅ Done with PR #114
  - Section 3: Marked doc alignment (#113), style guide (#112), and handoff (#111) as ✅ Done

## Verification
- ✅ Pre-commit hooks passed (dotnet format + build)
- ✅ All tracking items now show accurate status
- ✅ All PR references are valid and linked