### PR TITLE
feat(uat): enforce simulation blocking and add smart platform-specific defaults

### DIFF
--- a/.github/agents/uat-tester.agent.md
+++ b/.github/agents/uat-tester.agent.md
@@ -28,6 +28,10 @@ Validate that generated markdown renders correctly in real-world PR environments
 ### ✅ Always Do
 - Prefer `scripts/uat-run.sh` for end-to-end UAT (single stable command)
 - Use `scripts/uat-github.sh` and `scripts/uat-azdo.sh` for targeted operations / debugging
+- **Platform-specific artifacts are automatically selected if not specified:**
+  - GitHub: `examples/comprehensive-demo/report.md` (standard diff format)
+  - Azure DevOps: `examples/comprehensive-demo/report-inline-diff.md` (inline diff format, if available)
+  - For simulations: use `artifacts/uat-simulation-*.md` (requires `UAT_SIMULATE=true`)
 - Before creating any PR, post the **exact Title and Description** in chat using the standard template (Problem / Change / Verification)
 - Post markdown as **PR comments** (not PR description)
 - Prefix comments with agent identifier (scripts do this automatically)
@@ -53,7 +57,7 @@ Validate that generated markdown renders correctly in real-world PR environments
 - Perform any verification beyond visual rendering in PRs
 - Run unrelated tasks while waiting for feedback
 - Use background polling (`nohup`, `&`) — poll in the foreground and act immediately on results
-- Bypass the UAT artifact guardrails (do not set `UAT_ALLOW_MINIMAL=1` for real UAT)
+- **Use simulation artifacts for real UAT** — scripts will reject them unless `UAT_SIMULATE=true` is explicitly set
 
 ## Response Style
 
@@ -136,7 +140,9 @@ Save this to `artifacts/uat-minimal.md` (or `artifacts/uat-simulation-YYYY-MM-DD
 ### Default Parameters
 
 When not specified by the user, use these defaults:
-- **Artifact**: Prefer `artifacts/uat-minimal.md` if present; otherwise use the most recently modified `.md` file in `artifacts/`
+- **Artifact (GitHub)**: `examples/comprehensive-demo/report.md` (automatically selected by `uat-github.sh`)
+- **Artifact (Azure DevOps)**: `examples/comprehensive-demo/report-inline-diff.md` (automatically selected by `uat-azdo.sh`)
+- **For simulations**: Use `artifacts/uat-simulation-*.md` and set `UAT_SIMULATE=true` environment variable
 - **UAT Branch Name**: `uat/simulation-YYYY-MM-DD` where YYYY-MM-DD is today's date
 - **If branch already exists**: Append `-v2`, `-v3`, etc. to make it unique
 

--- a/scripts/uat-azdo.sh
+++ b/scripts/uat-azdo.sh
@@ -30,6 +30,43 @@ log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
+# Validate and set default artifact path
+# Args: $1=artifact path (or empty for default), $2=simulate flag, $3=force flag
+validate_artifact() {
+    local artifact="${1:-}"
+    local simulate="${2:-false}"
+    local force="${3:-false}"
+    
+    # Default to comprehensive demo with inline-diff format for Azure DevOps
+    if [[ -z "$artifact" ]]; then
+        # Azure DevOps requires inline-diff format for better rendering
+        if [[ -f "examples/comprehensive-demo/report-inline-diff.md" ]]; then
+            artifact="examples/comprehensive-demo/report-inline-diff.md"
+        else
+            # Fallback to standard format if inline-diff not available
+            artifact="examples/comprehensive-demo/report.md"
+        fi
+        log_info "No artifact specified, using Azure DevOps default: $artifact"
+    fi
+    
+    # Check if artifact exists
+    if [[ ! -f "$artifact" ]]; then
+        log_error "Artifact not found: $artifact"
+        exit 1
+    fi
+    
+    # Block simulation artifacts in real UAT runs
+    if [[ "$artifact" =~ simulation ]] && [[ "$simulate" != "true" ]] && [[ "$force" != "true" ]]; then
+        log_error "Simulation artifact detected: $artifact"
+        log_error "Simulation artifacts should not be used for real UAT."
+        log_error "Use --simulate flag for simulation mode, or --force to override."
+        exit 1
+    fi
+    
+    log_info "✓ Using artifact: $artifact"
+    echo "$artifact"
+}
+
 cmd_setup() {
     log_info "Checking Azure CLI authentication..."
     if ! az account show >/dev/null 2>&1; then
@@ -51,22 +88,11 @@ cmd_setup() {
 
 cmd_create() {
     local file="${1:-}"
-    if [[ -z "$file" || ! -f "$file" ]]; then
-        log_error "Usage: $0 create <markdown-file>"
-        exit 1
-    fi
-
-    # Guardrail: prevent accidental posting of minimal/simulation artifacts for real UAT.
-    # Override by setting UAT_ALLOW_MINIMAL=1 (intended for simulate-uat).
-    if [[ "${UAT_ALLOW_MINIMAL:-}" != "1" ]]; then
-        if echo "$(basename "$file")" | grep -qiE '(minimal|simulation)'; then
-            log_error "Refusing to use a minimal/simulation artifact for real UAT: $file"
-            log_error "Use artifacts/comprehensive-demo.md (recommended), or set UAT_ALLOW_MINIMAL=1 to override."
-            exit 1
-        fi
-    fi
+    local simulate="${UAT_SIMULATE:-false}"
+    local force="${UAT_FORCE:-false}"
     
-    log_info "Using artifact: $file"
+    # Validate and potentially set default artifact
+    file="$(validate_artifact "$file" "$simulate" "$force")"
 
     local branch
     branch=$(git branch --show-current)


### PR DESCRIPTION
## Problem
The retrospective identified that UAT initially failed because a simulation artifact was accidentally used instead of a comprehensive demo. The current guardrails were insufficient:
- Scripts checked for "minimal/simulation" patterns but required manual override (`UAT_ALLOW_MINIMAL=1`)
- No smart defaults per platform (GitHub vs Azure DevOps have different diff format requirements)
- Unclear separation between real UAT and simulation mode

## Changes

### Script Validation Enhancements
- **Added `validate_artifact()` function** to both `scripts/uat-github.sh` and `scripts/uat-azdo.sh`:
  - Blocks simulation artifacts in real UAT runs (unless `UAT_SIMULATE=true` or `UAT_FORCE=true`)
  - Provides platform-specific smart defaults when no artifact specified:
    - GitHub: `examples/comprehensive-demo/report.md` (standard diff)
    - Azure DevOps: `examples/comprehensive-demo/report-inline-diff.md` (inline diff, better rendering)
  - Validates artifact exists before proceeding
  - Prints clear confirmation of which artifact will be used

### Wrapper Script Improvements
- **Updated `scripts/uat-run.sh`**:
  - Removed duplicate validation logic (now delegated to individual platform scripts)
  - Allows individual scripts to apply platform-specific defaults
  - Simplified artifact handling

### Agent Documentation
- **Updated UAT Tester agent** (`.github/agents/uat-tester.agent.md`):
  - Documents automatic platform-specific defaults
  - Clarifies simulation mode requires `UAT_SIMULATE=true`
  - Removes outdated references to `UAT_ALLOW_MINIMAL` (replaced with `UAT_SIMULATE`)

## Verification
- ✅ Pre-commit hooks passed (dotnet format + build)
- ✅ Bash syntax validation passed for all three scripts
- ✅ Scripts now reject simulation artifacts by default
- ✅ Scripts provide helpful error messages with override instructions
- ✅ Maintains backward compatibility (explicit artifact paths still work)

## Examples

**Real UAT with defaults (no artifact specified):**
```bash
scripts/uat-github.sh create
# → Uses examples/comprehensive-demo/report.md

scripts/uat-azdo.sh create  
# → Uses examples/comprehensive-demo/report-inline-diff.md
```

**Simulation mode:**
```bash
UAT_SIMULATE=true scripts/uat-github.sh create artifacts/uat-simulation.md
# → Allowed because UAT_SIMULATE=true
```

**Accidental simulation (blocked):**
```bash
scripts/uat-github.sh create artifacts/uat-simulation.md
# → ERROR: Simulation artifact detected
# → Use --simulate flag or --force to override
```