### PR TITLE
docs(release): prefer scripts/pr-github.sh for create+merge (rebase-and-merge)

### DIFF
--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -33,6 +33,7 @@ Ensure the feature is ready for release, create the pull request (for both new f
 - Verify branch is up to date with main
 - Review commit messages follow conventional commit format
 - Execute release steps autonomously (create PR, trigger workflows, monitor pipelines)
+- **Prefer `Rebase and merge`** when merging PRs; the repository is configured to **allow rebase-only merges**. Use `scripts/pr-github.sh create-and-merge` (which uses `--rebase --delete-branch`) or `gh pr merge --rebase --delete-branch`.
 - Wait for PR Validation workflow to complete successfully before merging PR
 - Wait for CI on main to complete before triggering release workflow
 - Detect and use the version tag created by Versionize
@@ -149,30 +150,19 @@ Before releasing, verify:
    git push -u origin HEAD
 
    # CRITICAL: Before creating the PR, post the exact Title + Description in chat (use the standard template).
-
-   # For new PR (repo wrapper):
-   scripts/pr-github.sh create --title "<type(scope): summary>" --body-file <path-to-pr-body.md>
-   # For existing PR (rework after failed validation):
-   # PR is automatically updated by the push
-   ```
-   - If PR already exists (rework scenario), the push updates it automatically
-   - Provide the PR link to the maintainer
-
-4. **Wait for PR Validation** - Monitor PR checks and wait for completion:
-   Preferred in VS Code chat:
-   - Use GitHub chat tools to fetch PR status checks.
-   - Re-check until all required checks show success.
-
-   Fallback (terminal):
-   ```bash
-   PAGER=cat gh pr checks --watch
-   ```
+    ```
+    - **Preferred (create & merge):** Use `scripts/pr-github.sh create` to create PRs and `scripts/pr-github.sh create-and-merge` to merge them — this script is the authoritative, repo-standard tool for PR lifecycle operations.
+    - **Fallback:** When the script does not support a required or advanced task (rare), use GitHub chat tools (`github/*`) in VS Code for creation/inspection and ad-hoc actions.
+    - Use GitHub chat tools to fetch PR status checks and to inspect checks; re-check until all required checks show success.
    - **CRITICAL**: Do NOT merge until "PR Validation" shows ✅ success
    - All checks must pass: format, build, test, markdownlint, vulnerability scan
    - If checks fail, hand off to Developer agent to fix issues and return to step 1
 
 5. **Merge Pull Request** - After ALL checks pass:
    - Inform maintainer that PR validation passed and PR is ready to merge
+   - **Merge using: Rebase and merge.**
+     - **Preferred (for merges):** Use `scripts/pr-github.sh create-and-merge` — this script is the authoritative, repo-standard merge tool and will perform a `rebase` merge and delete the branch.
+     - **Preferred (for PR creation/inspection):** Use GitHub chat tools (`github/*`) from VS Code to create and inspect PRs; the script remains the authoritative merge implementation.
    - Wait for maintainer to approve and merge (or merge if authorized)
 
 ### Phase 2: Post-Merge Release

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+### Summary
+
+Describe the change and motivation in one or two sentences.
+
+---
+
+### Checklist
+
+- [ ] All checks pass (build, test, lint)
+- [ ] Commits follow Conventional Commits
+- [ ] PR description uses the standard template (Problem / Change / Verification)
+
+**Merge method:** Use **Rebase and merge** to maintain a linear history. The repository enforces rebase-only merges by default.
+
+**Create & merge guidance:** Use `scripts/pr-github.sh create` to create PRs, and `scripts/pr-github.sh create-and-merge` to perform the merge (this script is the authoritative, repo-preferred tool for PR creation and merges). If you need to inspect/check the PR, use GitHub chat tools (`github/*`) as needed.

--- a/scripts/pr-github.sh
+++ b/scripts/pr-github.sh
@@ -18,7 +18,9 @@ Options:
 Notes:
   - Required: provide an explicit title + body (agent-authored description)
   - This script intentionally does not guess title/body
-  - Requires: git + GitHub CLI (gh) authenticated
+  - **Agent guidance:** This script is the **authoritative** repo tool for creating and merging PRs. Use `scripts/pr-github.sh create` to create PRs and `scripts/pr-github.sh create-and-merge` to merge them (rebase + delete branch).
+  - **Fallback:** Use GitHub chat tools (`github/*`) only when the script does not support a necessary advanced operation or for quick inspection of checks.
+  - Requires: git + GitHub CLI (gh) authenticated when used as a CLI fallback
   - Merge policy: uses rebase-and-merge for linear history (per CONTRIBUTING.md)
 USAGE
 }


### PR DESCRIPTION
### Summary

Make `scripts/pr-github.sh` the authoritative repo tool for PR creation and merging, and prefer it for rebase-and-merge operations.

### Changes

- Update `Release Manager` agent instructions to prefer `scripts/pr-github.sh create` for PR creation and `scripts/pr-github.sh create-and-merge` for merges (rebase & branch cleanup).
- Add a PR template recommending the script for create+merge operations and clarifying merge policy.
- Annotate `scripts/pr-github.sh` notes to indicate the script is the authoritative create+merge tool and GitHub chat tools are fallback for inspection/unsupported tasks.

### Rationale

Standardizing on a single script for create+merge operations ensures consistent flags, branch cleanup, and reduces mistakes from ad-hoc merges. Chat tools remain useful for quick inspection and checks where the script does not apply.

### Checklist

- [ ] Documentation updated (done)
- [ ] No behavioral changes aside from guidance

