### PR TITLE
fix(ci): ensure workflows can push tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: true
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -85,4 +86,9 @@ jobs:
 
       - name: Push changes
         if: steps.versionize.outcome == 'success'
-        run: git push --follow-tags
+        env:
+          GIT_TERMINAL_PROMPT: '0'
+        run: |
+          # Ensure we push using the workflow token even if default auth was altered
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git push --follow-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: true
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Extract version from tag
@@ -51,8 +52,10 @@ jobs:
         id: previous_release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_PAGER: cat
+          PAGER: cat
         run: |
-          last=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
+          last=$(GH_PAGER=cat gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
           last=${last#v}
           echo "last=${last}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- keep checkout credentials and push using workflow token
- avoid pager blocking in release gh step

## Testing
- not run (workflow change)