### PR TITLE
docs: mark q4 workflow roadmap complete

### DIFF
--- a/docs/roadmap-workflow-improvements-2025-q4.md
+++ b/docs/roadmap-workflow-improvements-2025-q4.md
@@ -2,7 +2,7 @@
 
 **Source:** [Retrospective: Consistent Value Formatting](features/consistent-value-formatting/retrospective.md)
 **Date:** 2025-12-25
-**Status:** In progress
+**Status:** Complete
 
 This roadmap outlines a series of workflow improvements derived from the "Consistent Value Formatting" feature retrospective. The goal is to reduce friction (especially in UAT), clarify agent roles, and improve process measurability.
 


### PR DESCRIPTION
## Problem
All roadmap items for Q4 workflow improvements are done, but the roadmap still showed status "In progress".

## Change
- Set the Q4 workflow improvements roadmap status to "Complete".

## Verification
- Husky pre-commit hooks: dotnet-format, dotnet-build (pass during commit).
- Docs-only change; no additional tests run.
