### PR TITLE
ci: use RELEASE_TOKEN to bypass branch protection for versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -89,6 +90,6 @@ jobs:
         env:
           GIT_TERMINAL_PROMPT: '0'
         run: |
-          # Ensure we push using the workflow token even if default auth was altered
-          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          # Use RELEASE_TOKEN to bypass branch protection
+          git remote set-url origin "https://x-access-token:${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }}.git"
           git push --follow-tags


### PR DESCRIPTION
The CI workflow failed because `GITHUB_TOKEN` cannot push to protected branches. This change uses a PAT (`RELEASE_TOKEN`) with repository write access to bypass branch protection for the Version and Tag job.

### Changes
- Use `RELEASE_TOKEN` for checkout in the version job (enables push with persisted credentials)
- Use `RELEASE_TOKEN` for pushing version bumps and tags

### Verification
- `RELEASE_TOKEN` secret has been created with Contents: Read and write permission