### PR TITLE
fix: remove quotes from EOF delimiter in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,9 +95,9 @@ jobs:
             TAGS="$TAGS\n${{ secrets.DOCKERHUB_USERNAME }}/tfplan2md:${{ needs.release.outputs.major }}"
             TAGS="$TAGS\n${{ secrets.DOCKERHUB_USERNAME }}/tfplan2md:latest"
           fi
-          echo "tags<<'EOF'" >> $GITHUB_OUTPUT
+          echo "tags<<EOF" >> $GITHUB_OUTPUT
           echo -e "$TAGS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo EOF >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Problem
The release workflow failed with "Invalid value. Matching delimiter not found 'EOF'" when computing Docker tags.

## Change
- Removed quotes from the EOF delimiter in the "Compute Docker tags" step in `.github/workflows/release.yml`.
- Changed `echo "tags<<'EOF'"` to `echo "tags<<EOF"` and `echo "EOF"` to `echo EOF`.

## Verification
- This is a syntax fix for GitHub Actions multiline output.
- The quoted delimiter was preventing proper parsing of the heredoc.
