### PR TITLE
fix(ci,agent): UAT validation check + Release Manager polling fixes

### DIFF
--- a/.github/workflows/uat-validate.yml
+++ b/.github/workflows/uat-validate.yml
@@ -3,20 +3,8 @@ name: UAT artifact validation
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'scripts/uat-helpers.sh'
-      - 'scripts/uat-github.sh'
-      - 'scripts/uat-azdo.sh'
-      - 'scripts/uat-run.sh'
-      - 'tests/shell/**'
   push:
     branches: [ main ]
-    paths:
-      - 'scripts/uat-helpers.sh'
-      - 'scripts/uat-github.sh'
-      - 'scripts/uat-azdo.sh'
-      - 'scripts/uat-run.sh'
-      - 'tests/shell/**'
 
 jobs:
   uat-validate:
@@ -27,9 +15,40 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history to detect changed files
+
+      - name: Check if UAT files changed
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            # For push events, compare with parent commit
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.sha }}"
+          fi
+          
+          # Check if any UAT-related files changed
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -E '^(scripts/uat-|tests/shell/)' || true)
+          
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No UAT-related files changed, skipping validation tests"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "UAT files changed, running validation tests"
+          fi
 
       - name: Ensure tests are executable
+        if: steps.filter.outputs.changed == 'true'
         run: chmod +x tests/shell/uat_validate_test.sh
 
       - name: Run UAT validation tests
+        if: steps.filter.outputs.changed == 'true'
         run: ./tests/shell/uat_validate_test.sh
+      
+      - name: Skip validation (no files changed)
+        if: steps.filter.outputs.changed == 'false'
+        run: echo "✅ No UAT files changed, validation skipped"

--- a/docs/workflow/improvements-2025-12-27.md
+++ b/docs/workflow/improvements-2025-12-27.md
@@ -30,7 +30,7 @@
 | **18** | Fix Versionize major release configuration | 🔲 Not Started | Critical | Medium | Critical |
 | **19** | Add rejection tracking to retrospective analysis | 🔲 Not Started | Low | High | Low |
 | **20** | Create workflow validation tool | 🔲 Not Started | High | High | High |
-| **21** | Fix "UAT artifact validation" GitHub status check | 🔲 Not Started | Critical | Low | Critical |
+| **21** | Fix "UAT artifact validation" GitHub status check | ✅ Complete | Critical | Low | Critical |
 
 ## Detailed Improvements
 


### PR DESCRIPTION
## Summary

Implements 2 critical workflow improvements:
- **#21**: UAT artifact validation GitHub check fix
- **#3**: Release Manager polling behavior fix

## #21: UAT Artifact Validation Check

### Problem
The "UAT artifact validation" required status check was expected by GitHub but never ran on most PRs, forcing manual policy overrides to merge.

The workflow had path filters that only triggered when specific files changed:
- `scripts/uat-*.sh`
- `tests/shell/**`

### Solution
- Workflow **always runs** on all PRs (satisfies GitHub requirement)
- Detects if UAT-related files changed
- **Conditionally skips** test execution when no UAT files changed
- **Runs full tests** when UAT files are modified

### Benefits
✅ Required check always exists - no more manual policy overrides  
✅ Minimal CI resource waste - skips tests when not needed  
✅ Full validation when UAT code changes

## #3: Release Manager Polling Fix

### Problem
Release Manager was flooding chat with polling messages and getting stuck in infinite reasoning loops:

```
Wait, I'll also check if the PR is approved.
Wait, I'll also check if the PR is mergeable.
Wait, I'll also check if the PR is approved.
Wait, I'll also check if the PR is mergeable.
...
```
(hundreds of similar messages)

### Solution
- Updated instructions to use `gh run watch <run-id>` (blocking wait)
- Added explicit step #4: "Wait for PR Validation to Complete" with blocking commands
- Added boundaries forbidding polling and chat flooding
- Clear guidance: ONE blocking call handles all waiting

### Benefits
✅ No more chat floods  
✅ Efficient waiting with single blocking command  
✅ Agent proceeds only after completion

## Impact

- **Priority:** Critical (#21 blocks merges, #3 causes severe UX issues)
- **Risk:** Low (workflow logic + instruction changes only)
- **Breaking:** No
- **Affected Components:**
  - CI/CD: UAT validation workflow
  - Agent: Release Manager behavior