### PR TITLE
fix(ci): run PR validation on workflow changes

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,7 +5,13 @@ on:
     branches: [main]
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
+      # Ignore agent workflow/instructions-only changes (the C# test suite doesn't validate these).
+      # Keep `.github/workflows/**` included so changes to CI/workflows are validated on PRs.
+      - '.github/agents/**'
+      - '.github/skills/**'
+      - '.github/copilot-instructions.md'
+      - '.github/gh-cli-instructions.md'
+      - '.github/pull_request_template.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Problem
The `PR Validation` workflow stopped running on pull requests that only change files under `.github/**` because the workflow was configured with `paths-ignore: .github/**`. That unintentionally excluded CI/workflow changes (e.g. `.github/workflows/*.yml`) from PR validation.

## Change
- Narrowed `paths-ignore` in `.github/workflows/pr-validation.yml` to ignore only agent instruction / skill / template files under `.github/`, while keeping `.github/workflows/**` included so workflow changes trigger PR validation.

## Verification
- Manual review of the workflow trigger rules.
