### PR TITLE
fix(ci): ensure PR validation runs for all PRs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,15 +3,6 @@ name: PR Validation
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      # Ignore agent workflow/instructions-only changes (the C# test suite doesn't validate these).
-      # Keep `.github/workflows/**` included so changes to CI/workflows are validated on PRs.
-      - '.github/agents/**'
-      - '.github/skills/**'
-      - '.github/copilot-instructions.md'
-      - '.github/gh-cli-instructions.md'
-      - '.github/pull_request_template.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -28,41 +19,79 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check if validation is needed
+        id: filter
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || true)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "No changed files detected; running validation"
+            exit 0
+          fi
+
+          NON_IGNORED=$(echo "$CHANGED_FILES" | grep -Ev '^(docs/|\.github/agents/|\.github/skills/|\.github/copilot-instructions\.md$|\.github/gh-cli-instructions\.md$|\.github/pull_request_template\.md$)' || true)
+
+          if [ -z "$NON_IGNORED" ]; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "Only docs/agent-instructions changed; skipping validation"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Non-ignored files changed; running validation"
+          fi
 
       - name: Setup .NET
+        if: steps.filter.outputs.changed == 'true'
         uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
       - name: Restore dependencies
+        if: steps.filter.outputs.changed == 'true'
         run: dotnet restore
 
       - name: Check formatting
+        if: steps.filter.outputs.changed == 'true'
         run: dotnet format --verify-no-changes --verbosity diagnostic
 
       - name: Build
+        if: steps.filter.outputs.changed == 'true'
         run: dotnet build --no-restore --configuration Release
 
       - name: Test
+        if: steps.filter.outputs.changed == 'true'
         run: dotnet test --no-build --configuration Release --verbosity normal
 
       - name: Setup Node
+        if: steps.filter.outputs.changed == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 20
 
       - name: Generate comprehensive demo report
+        if: steps.filter.outputs.changed == 'true'
         run: |
           mkdir -p artifacts
           dotnet run --project src/Oocx.TfPlan2Md/Oocx.TfPlan2Md.csproj -- examples/comprehensive-demo/plan.json --principals examples/comprehensive-demo/demo-principals.json --output artifacts/comprehensive-demo.md
 
       - name: Lint comprehensive demo markdown
+        if: steps.filter.outputs.changed == 'true'
         run: npx markdownlint-cli2 artifacts/comprehensive-demo.md
 
       - name: Check for vulnerable packages
+        if: steps.filter.outputs.changed == 'true'
         run: |
           dotnet list package --vulnerable --include-transitive 2>&1 | tee vulnerability-report.txt
           if grep -q "has the following vulnerable packages" vulnerability-report.txt; then
             echo "::error::Vulnerable packages detected!"
             exit 1
           fi
+
+      - name: Skip validation (no relevant files changed)
+        if: steps.filter.outputs.changed == 'false'
+        run: echo "✅ PR validation skipped (docs/agent-only changes)"

--- a/docs/workflow/improvements-2025-12-27.md
+++ b/docs/workflow/improvements-2025-12-27.md
@@ -31,6 +31,7 @@
 | **19** | Add rejection tracking to retrospective analysis | 🔲 Not Started | Low | High | Low |
 | **20** | Create workflow validation tool | 🔲 Not Started | High | High | High |
 | **21** | Fix "UAT artifact validation" GitHub status check | ✅ Complete | Critical | Low | Critical |
+| **22** | Fix "PR Validation" GitHub status check | ✅ Complete | Critical | Low | Critical |
 
 ## Detailed Improvements
 


### PR DESCRIPTION
## Problem
The “PR Validation” workflow can be skipped due to `paths-ignore`, leaving the required status check in an “Expected” state and blocking merges.

## Change
- Update the PR validation workflow to run on all PRs to `main`.
- Replace event-level `paths-ignore` with an in-workflow change detector:
  - Detect whether non-ignored files changed between PR base/head
  - Run validation only when needed; otherwise exit successfully with an explicit “skipped” step
- Track the improvement in the workflow improvements checklist.

## Verification
- Commit hooks ran successfully (`dotnet format`, `dotnet build`).
- Workflow YAML edits are syntactically valid (no editor diagnostics).
