### PR TITLE
docs(workflow): add visual feedback analysis and commit amend guideline to all agents

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -42,6 +42,7 @@ Transform a Feature Specification into a clear technical design with documented 
 - Address security, reliability, and maintainability concerns
 - Create or update markdown documentation files in docs/ or docs/features/NNN-<feature-slug>/
 - Commit architecture documents when approved
+- **Commit Amending:** If you need to fix issues or apply feedback for the commit you just created, use `git commit --amend` instead of creating a new "fix" commit.
 
 ### ⚠️ Ask First
 - Proposing significant changes to existing architecture
@@ -59,6 +60,7 @@ Transform a Feature Specification into a clear technical design with documented 
 - Create ADRs without considering multiple options
 - Design without reviewing existing codebase patterns
 - Skip documenting the rationale for decisions
+- Create "fixup" or "fix" commits for work you just committed; use `git commit --amend` instead.
 
 ## Response Style
 

--- a/.github/agents/issue-analyst.agent.md
+++ b/.github/agents/issue-analyst.agent.md
@@ -47,6 +47,7 @@ Gather diagnostic information, perform initial analysis, and document the proble
 - Create issue analysis document at docs/issues/NNN-<issue-slug>/analysis.md
 - Propose initial analysis, not final solutions
 - Commit analysis document before handing off to Developer
+- **Commit Amending:** If you need to fix issues or apply feedback for the commit you just created, use `git commit --amend` instead of creating a new "fix" commit.
 
 ### ⚠️ Ask First
 - If the issue requires access to external systems or credentials
@@ -60,6 +61,7 @@ Gather diagnostic information, perform initial analysis, and document the proble
 - Make assumptions without verification
 - Skip diagnostic steps
 - Change code without proper branch and handoff
+- Create "fixup" or "fix" commits for work you just committed; use `git commit --amend` instead.
 
 ## Response Style
 

--- a/.github/agents/quality-engineer.agent.md
+++ b/.github/agents/quality-engineer.agent.md
@@ -32,7 +32,7 @@ Create a test plan that maps test cases to acceptance criteria, ensuring the fea
 - Create test plan markdown file at `docs/features/NNN-<feature-slug>/test-plan.md`
 - Create UAT test plan (if needed) at `docs/features/NNN-<feature-slug>/uat-test-plan.md`
 - Commit test plan when approved
-
+- **Commit Amending:** If you need to fix issues or apply feedback for the commit you just created, use `git commit --amend` instead of creating a new "fix" commit.
 
 ### ⚠️ Ask First
 - Adding new test infrastructure or frameworks
@@ -46,6 +46,7 @@ Create a test plan that maps test cases to acceptance criteria, ensuring the fea
 - Skip testing error conditions or edge cases
 - Write test cases without linking them to acceptance criteria
 - Propose tests that require human judgment to pass/fail (except for UAT)
+- Create "fixup" or "fix" commits for work you just committed; use `git commit --amend` instead.
 
 ## Response Style
 

--- a/.github/agents/requirements-engineer.agent.md
+++ b/.github/agents/requirements-engineer.agent.md
@@ -41,6 +41,7 @@ Transform an initial feature idea into a clear, unambiguous Feature Specificatio
 - Summarize understanding before writing specification
 - Define measurable success criteria from user perspective
 - Commit specification when approved by the Maintainer
+- **Commit Amending:** If you need to fix issues or apply feedback for the commit you just created, use `git commit --amend` instead of creating a new "fix" commit.
 
 ### ⚠️ Ask First
 - If the request seems like a bug fix rather than a feature
@@ -56,6 +57,7 @@ Transform an initial feature idea into a clear, unambiguous Feature Specificatio
 - Write specification before understanding is confirmed
 - Add features or scope not requested by maintainer
 - Create feature specifications for bug fixes
+- Create "fixup" or "fix" commits for work you just committed; use `git commit --amend` instead.
 
 ## Response Style
 

--- a/.github/agents/task-planner.agent.md
+++ b/.github/agents/task-planner.agent.md
@@ -54,6 +54,7 @@ Break down the feature into clear, prioritized work items with well-defined acce
 - Create and own tasks.md (this is your exclusive deliverable)
 - **STOP after creating the plan and explicitly request approval**
 - Commit tasks document only after maintainer approval
+- **Commit Amending:** If you need to fix issues or apply feedback for the commit you just created, use `git commit --amend` instead of creating a new "fix" commit.
 - Use handoff button to transition to Developer after approval
 
 ### ⚠️ Ask First
@@ -70,6 +71,7 @@ Break down the feature into clear, prioritized work items with well-defined acce
 - **Write source code, tests, or make code changes** — your role is planning only
 - **Proceed past the planning phase** — hand off to Developer after the plan is approved
 - **Skip the approval step** — always wait for maintainer confirmation before committing
+- Create "fixup" or "fix" commits for work you just committed; use `git commit --amend` instead.
 
 ## Response Style
 

--- a/.github/agents/workflow-engineer.agent.md
+++ b/.github/agents/workflow-engineer.agent.md
@@ -27,6 +27,7 @@ Evolve and optimize the agent workflow by creating new agents, modifying existin
 - Ensure Mermaid diagram reflects all agents and artifacts
 - Test proposed changes incrementally
 - Skip `dotnet test` when changes are limited to agent instructions / skills / documentation (e.g., `.github/agents/`, `.github/skills/`, `.github/copilot-instructions.md`, `docs/`) since the test suite doesn't validate those changes; run `dotnet test` when C# code changes
+- **Commit Amending:** If you need to fix issues or apply feedback for the commit you just created, use `git commit --amend` instead of creating a new "fix" commit.
 
 ### ⚠️ Ask First
 - Before removing an existing agent
@@ -41,6 +42,7 @@ Evolve and optimize the agent workflow by creating new agents, modifying existin
 - Skip documentation updates
 - Change agent core responsibilities without approval
 - Add handoffs to non-existent agents
+- Create "fixup" or "fix" commits for work you just committed; use `git commit --amend` instead.
 
 ## Response Style
 

--- a/docs/workflow/025-improvements-2025-12-29/workflow-improvements.md
+++ b/docs/workflow/025-improvements-2025-12-29/workflow-improvements.md
@@ -4,23 +4,41 @@ Based on the retrospective from [Visual Report Enhancements](../../features/024-
 
 ## Proposed Improvements
 
-| # | Improvement | Description | Value | Effort | Priority |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| 1 | **Safe Merge Script** | Create `scripts/safe-merge.sh` to verify file integrity (size/content) post-merge, preventing the documentation loss seen in feature 024. | **High** | Medium | **Critical** |
-| 2 | **Visual Feedback Skill** | Implement `.github/skills/visual-validator/` to allow agents to "see" rendered markdown (e.g., via image conversion), reducing retries for visual alignment. | **High** | High | High |
-| 3 | **UAT Signal Detection** | Enhance `scripts/uat-run.sh` or create a skill to explicitly flag "reject/fail" signals in test output, preventing UAT Tester oversight. | **Medium** | Medium | Medium |
-| 4 | **Detail Checklist Gate** | Update the **Developer** agent prompt to require a "Detail Checklist" for features with many small UI/UX items to prevent quality slips. | **Medium** | Low | Medium |
-| 5 | **Merge Conflict Guardrail** | Update **Release Manager** instructions to require a manual "Conflict Check" step before finalizing merges, even if the CLI reports success. | **Medium** | Low | High |
-| 6 | **Commit Amend Guideline** | Update **Developer** instructions to amend the previous commit when fixing issues in the commit just created (e.g., based on feedback), ensuring a clean "1 topic per commit" history. | **Medium** | Low | Medium |
-| 7 | **Model Outage Protocol** | Define a fallback protocol for agents when primary models (like `gpt-5.1-codex-max`) are unavailable to ensure consistent quality. | **Low** | Low | Low |
+| # | Improvement | Description | Value | Effort | Priority | Status |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| 1 | **Safe Merge Script** | Create `scripts/safe-merge.sh` to verify file integrity (size/content) post-merge, preventing the documentation loss seen in feature 024. | **High** | Medium | **Critical** | Open |
+| 2 | **Markdown Syntax Validator** | Create `scripts/validate-markdown.sh` to detect broken tables/headings before UAT. | **Medium** | Low | Medium | Open |
+| 3 | **UAT Signal Detection** | Enhance `scripts/uat-run.sh` or create a skill to explicitly flag "reject/fail" signals in test output, preventing UAT Tester oversight. | **Medium** | Medium | Medium | Open |
+| 4 | **Detail Checklist Gate** | Update the **Developer** agent prompt to require a "Detail Checklist" for features with many small UI/UX items to prevent quality slips. | **Medium** | Low | Medium | ✅ Done |
+| 5 | **Merge Conflict Guardrail** | Update **Release Manager** instructions to require a manual "Conflict Check" step before finalizing merges, even if the CLI reports success. | **Medium** | Low | High | ✅ Done |
+| 6 | **Commit Amend Guideline** | Update **Developer** instructions to amend the previous commit when fixing issues in the commit just created (e.g., based on feedback), ensuring a clean "1 topic per commit" history. | **Medium** | Low | Medium | ✅ Done |
+| 7 | **Model Outage Protocol** | Define a fallback protocol for agents when primary models (like `gpt-5.1-codex-max`) are unavailable to ensure consistent quality. | **Low** | Low | Low | Open |
 
 ## Recommendations
 
 ### 1. Safe Merge Script (Critical)
 This is the highest priority because it addresses the **Critical Workflow Failure** where documentation was lost during the release phase. While the Visual Feedback Skill offers high value for development speed, the Safe Merge Script is essential for repository integrity.
 
-### 2. Visual Feedback Skill (High)
-The Developer agent struggled with Azure DevOps alignment and spacing issues due to the lack of visual feedback. Providing a way for agents to "see" the rendered output will significantly reduce the number of retries and manual interventions.
+### 2. ~~Visual Feedback Skill~~ → Markdown Syntax Validator (Revised)
+
+**Analysis (2025-12-29):** After discussion, we determined that the "visual feedback" problems from feature 024 fall into three categories:
+
+| Problem Type | AI Can Solve Alone? | Solution |
+| :--- | :--- | :--- |
+| **Syntax errors** (broken tables/headings) | ✅ Yes | Static validation before UAT |
+| **Code completeness** (missing icons) | ✅ Yes | Better checklists + test coverage |
+| **Spacing/margins** | ❌ No | Requires human feedback |
+
+**Key insights:**
+- Broken tables and headings are **syntax errors**, not visual rendering issues. They can be detected with static analysis (column count mismatches, missing separators, headline formatting).
+- Missing icons were a **code completeness** issue—the agent missed cases in logic, not a failure to "see" the output.
+- Spacing/margin issues require **aesthetic judgment**—AI cannot determine if spacing is "too much" or "too little" without human feedback.
+
+**Conclusion:** A screenshot-based visual feedback skill would be high effort and low value because:
+1. Most problems can be caught with simpler static analysis.
+2. Aesthetic judgment (spacing) cannot be automated—it still requires Maintainer feedback.
+
+**Replacement:** Create `scripts/validate-markdown.sh` to detect broken tables and headings before UAT.
 
 ### 3. Merge Conflict Guardrail (High)
 Even with a script, the Release Manager should have a manual verification step to ensure that the merge result is as expected, especially for critical documentation files.
@@ -29,6 +47,6 @@ Even with a script, the Release Manager should have a manual verification step t
 To maintain a clean history, agents should avoid "fixup" commits for work they just did. If feedback requires changes to the most recent commit, agents should use `git commit --amend` instead of creating a new commit.
 
 ## Next Steps
-1. Implement `scripts/safe-merge.sh`.
-2. Update `docs/agents.md` with the new Developer checklist requirement.
-3. Research markdown-to-image rendering tools for the Visual Feedback Skill.
+1. Implement `scripts/safe-merge.sh` (Critical).
+2. ~~Research markdown-to-image rendering tools for the Visual Feedback Skill.~~ (Deprioritized - see analysis above)
+3. Implement `scripts/validate-markdown.sh` for broken table/heading detection (Medium priority).


### PR DESCRIPTION
## Problem
1. The Visual Feedback Skill was listed as high priority but needed analysis.
2. Commit amend guideline was only applied to Developer and Release Manager, not all agents that commit.

## Change
- Added detailed analysis of visual feedback problems (most are syntax errors, not visual rendering issues)
- Replaced "Visual Feedback Skill" with "Markdown Syntax Validator" (lower effort, addresses actual problems)
- Applied commit amend guideline to all 7 agents that commit:
  - Developer, Requirements Engineer, Architect, Quality Engineer, Task Planner, Issue Analyst, Workflow Engineer
- Updated workflow improvements status to reflect completed items

## Verification
- Analysis documented in workflow-improvements.md
- All committing agents now have commit amend instructions in both "Always Do" and "Never Do" sections
