### PR TITLE
feat(workflow): add dotnet test timeout wrapper

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -31,7 +31,7 @@ Review the implementation thoroughly and produce a Code Review Report that eithe
 
 ### ✅ Always Do
 - Check Docker availability before running Docker build (ask maintainer to start if needed)
-- Run `dotnet test` and `docker build` to verify functionality
+- Run `scripts/test-with-timeout.sh -- dotnet test` and `docker build` to verify functionality
 - Generate comprehensive demo output and verify it passes markdownlint (always, not just when feature impacts markdown)
 - Check that all acceptance criteria are met
 - Verify adherence to C# coding conventions
@@ -102,7 +102,7 @@ Before starting, familiarize yourself with:
 ### Correctness
 - [ ] Code implements all acceptance criteria from the tasks
 - [ ] All test cases from the test plan are implemented
-- [ ] Tests pass (`dotnet test`)
+- [ ] Tests pass (`scripts/test-with-timeout.sh -- dotnet test`)
 - [ ] No workspace problems (`problems`) after build/test
 - [ ] Docker image builds and feature works in container
 
@@ -166,7 +166,7 @@ Before starting, familiarize yourself with:
 
 2. **Run verification** - Execute tests and check for errors:
    ```bash
-   dotnet test
+  scripts/test-with-timeout.sh -- dotnet test
    docker build -t tfplan2md:local .
    ```
 

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -194,7 +194,7 @@ Follow the project's coding conventions strictly:
    
    c. **Verify acceptance criteria** for the current task:
       - All acceptance criteria for THIS task must be satisfied
-      - Run relevant tests: `dotnet test --filter "<TestClass>"`
+      - Run relevant tests: `scripts/test-with-timeout.sh -- dotnet test --filter "<TestClass>"`
       - Check for errors: Use `problems` to verify no workspace errors
    
    d. **Commit the task**:
@@ -219,7 +219,7 @@ Follow the project's coding conventions strictly:
    
    a. **Run full test suite**:
       ```bash
-      dotnet test
+   scripts/test-with-timeout.sh -- dotnet test
       ```
       - All tests must pass with ZERO skipped tests
       - If tests are skipped, identify reason and ask Maintainer to resolve
@@ -261,12 +261,17 @@ dotnet build
 
 Run all tests:
 ```bash
-dotnet test
+scripts/test-with-timeout.sh -- dotnet test
+```
+
+Override timeout (if needed):
+```bash
+scripts/test-with-timeout.sh --timeout-seconds <seconds> -- dotnet test
 ```
 
 Run specific test file:
 ```bash
-dotnet test --filter "FullyQualifiedName~ClassName"
+scripts/test-with-timeout.sh -- dotnet test --filter "FullyQualifiedName~ClassName"
 ```
 
 Build the Docker image:
@@ -318,7 +323,7 @@ Verify:
 
 Verify:
 - [ ] All tasks are complete and marked as done in tasks.md
-- [ ] Full test suite passes with ZERO skipped tests (`dotnet test`)
+- [ ] Full test suite passes with ZERO skipped tests (`scripts/test-with-timeout.sh -- dotnet test`)
 - [ ] Docker image builds successfully (`docker build`)
 - [ ] Feature works correctly when running in the Docker container
 - [ ] Demo artifacts regenerated using `generate-demo-artifacts` skill (REQUIRED)

--- a/.github/agents/issue-analyst.agent.md
+++ b/.github/agents/issue-analyst.agent.md
@@ -156,7 +156,7 @@ git log --oneline --since="1 week ago" -- <relevant-path>
 dotnet build --no-restore
 
 # Run tests
-dotnet test --verbosity normal
+scripts/test-with-timeout.sh -- dotnet test --verbosity normal
 
 # Check for problems in workspace
 # Use the 'problems' tool to see diagnostics

--- a/.github/agents/quality-engineer.agent.md
+++ b/.github/agents/quality-engineer.agent.md
@@ -27,7 +27,7 @@ Create a test plan that maps test cases to acceptance criteria, ensuring the fea
 - For user-facing features (CLI changes, rendering changes), define **UAT Test Plans** for Maintainer review via PRs in `docs/features/NNN-<feature-slug>/uat-test-plan.md`
 - Follow xUnit and AwesomeAssertions patterns
 - Use test naming convention: `MethodName_Scenario_ExpectedResult`
-- Verify tests can run via `dotnet test` without human intervention
+- Verify tests can run via `scripts/test-with-timeout.sh -- dotnet test` without human intervention
 - Consider edge cases, error conditions, and boundary values
 - Create test plan markdown file at `docs/features/NNN-<feature-slug>/test-plan.md`
 - Create UAT test plan (if needed) at `docs/features/NNN-<feature-slug>/uat-test-plan.md`
@@ -86,7 +86,7 @@ This project uses:
 - **Test Data**: JSON files in `tests/Oocx.TfPlan2Md.Tests/TestData/`
 - **Docker Integration Tests**: For end-to-end CLI testing
 
-**Important constraint:** All tests must be fully automated. No manual testing steps are acceptable. Every test case must be executable via `dotnet test` without human intervention.
+**Important constraint:** All tests must be fully automated. No manual testing steps are acceptable. Every test case must be executable via `dotnet test` without human intervention (typically executed via `scripts/test-with-timeout.sh -- dotnet test` to prevent hangs). If a custom timeout is required, add `--timeout-seconds <seconds>`.
 
 Follow the existing test naming convention: `MethodName_Scenario_ExpectedResult`
 

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -27,7 +27,7 @@ Ensure the feature is ready for release, create the pull request (for both new f
 
 ### ✅ Always Do
 - Verify code review is approved before proceeding
-- Trust CI pipeline for test validation — only run local tests (`dotnet test`) if diagnosing a specific CI failure
+- Trust CI pipeline for test validation — only run local tests (`scripts/test-with-timeout.sh -- dotnet test`) if diagnosing a specific CI failure
 - Verify Docker image builds successfully (only if not recently verified by Code Reviewer)
 - Check that working directory is clean
 - Verify branch is up to date with main
@@ -130,7 +130,7 @@ Before releasing, verify:
 2. **Tests Pass** (trust CI — only run locally if debugging a failure)
    ```bash
    # Only if CI failed and you need to reproduce:
-   dotnet test
+   scripts/test-with-timeout.sh -- dotnet test
    ```
 
 3. **Docker Build Succeeds** (only if not recently verified by Code Reviewer)

--- a/.github/agents/workflow-engineer.agent.md
+++ b/.github/agents/workflow-engineer.agent.md
@@ -26,7 +26,7 @@ Evolve and optimize the agent workflow by creating new agents, modifying existin
 - Use conventional commit messages (`feat:`, `refactor:`, `fix:`, `docs:`)
 - Ensure Mermaid diagram reflects all agents and artifacts
 - Test proposed changes incrementally
-- Skip `dotnet test` when changes are limited to agent instructions / skills / documentation (e.g., `.github/agents/`, `.github/skills/`, `.github/copilot-instructions.md`, `docs/`) since the test suite doesn't validate those changes; run `dotnet test` when C# code changes
+- Skip `dotnet test` when changes are limited to agent instructions / skills / documentation (e.g., `.github/agents/`, `.github/skills/`, `.github/copilot-instructions.md`, `docs/`) since the test suite doesn't validate those changes; run tests via `scripts/test-with-timeout.sh -- dotnet test` when C# code changes
 - **Commit Amending:** If you need to fix issues or apply feedback for the commit you just created, use `git commit --amend` instead of creating a new "fix" commit.
 
 ### ⚠️ Ask First
@@ -457,7 +457,7 @@ Help with development tasks
 Implement features and tests according to specifications, following C# coding conventions and test-first development.
 
 ## Boundaries
-✅ Always: Write tests before code; run `dotnet test` before committing when C# code changes
+✅ Always: Write tests before code; run `scripts/test-with-timeout.sh -- dotnet test` before committing when C# code changes
 ⚠️ Ask First: Database schema changes, adding NuGet packages
 🚫 Never: Edit CHANGELOG.md (auto-generated), commit to main
 ```
@@ -472,7 +472,8 @@ Run tests to verify your changes.
 ```markdown
 ## Commands
 - **Build:** `dotnet build` - Compiles solution, check for errors
-- **Test:** `dotnet test` - Runs all tests; required when C# code changes (not needed for agent/docs-only changes)
+- **Test:** `scripts/test-with-timeout.sh -- dotnet test` - Runs all tests; required when C# code changes (not needed for agent/docs-only changes)
+   - Override timeout if needed: `scripts/test-with-timeout.sh --timeout-seconds <seconds> -- dotnet test`
 - **Format:** `dotnet format` - Auto-formats code to match .editorconfig
 ```
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,9 @@ For project-specific instructions, refer to the `docs/spec.md` file in the repos
   - For `gh`: Use `GH_PAGER=cat GH_FORCE_TTY=false gh ...` or `export GH_PAGER=cat GH_FORCE_TTY=false`.
   - For `az`: Use `AZURE_CORE_PAGER=cat az ...` or `export AZURE_CORE_PAGER=cat`.
   - For general tools: Use `export PAGER=cat`.
+- **Test hangs**: When running the full test suite, use the timeout wrapper instead of calling `dotnet test` directly.
+  - Example: `scripts/test-with-timeout.sh -- dotnet test --no-build --configuration Release --verbosity normal`
+  - If you need a different timeout: `scripts/test-with-timeout.sh --timeout-seconds <seconds> -- dotnet test ...`
 - **Workspace-local temp files**: Do not create or reference temporary files outside the repository (for example `/tmp` or `~/`). If a scratch file is needed, write it under `.tmp/` (create it with `scripts/setup-tmp.sh` if needed).
 - Avoid running commands that are not necessary for the current task.
 - When a command fails, explain the error and propose a solution before retrying.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
+      - name: Shell test (timeout wrapper)
+        run: bash tests/shell/test_with_timeout_test.sh
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -38,7 +41,9 @@ jobs:
         run: dotnet build --no-restore --configuration Release
 
       - name: Test
-        run: dotnet test --no-build --configuration Release --verbosity normal
+        run: |
+          chmod +x scripts/test-with-timeout.sh
+          scripts/test-with-timeout.sh --timeout-seconds 3600 -- dotnet test --no-build --configuration Release --verbosity normal
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -45,6 +45,10 @@ jobs:
             echo "Non-ignored files changed; running validation"
           fi
 
+      - name: Shell test (timeout wrapper)
+        if: steps.filter.outputs.changed == 'true'
+        run: bash tests/shell/test_with_timeout_test.sh
+
       - name: Setup .NET
         if: steps.filter.outputs.changed == 'true'
         uses: actions/setup-dotnet@v5
@@ -65,7 +69,9 @@ jobs:
 
       - name: Test
         if: steps.filter.outputs.changed == 'true'
-        run: dotnet test --no-build --configuration Release --verbosity normal
+        run: |
+          chmod +x scripts/test-with-timeout.sh
+          scripts/test-with-timeout.sh --timeout-seconds 3600 -- dotnet test --no-build --configuration Release --verbosity normal
 
       - name: Setup Node
         if: steps.filter.outputs.changed == 'true'

--- a/scripts/test-with-timeout.sh
+++ b/scripts/test-with-timeout.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper to prevent hung test runs.
+#
+# Usage:
+#   scripts/test-with-timeout.sh [--timeout-seconds <n>] [--grace-seconds <n>] [dotnet-test-args...]
+#   scripts/test-with-timeout.sh [--timeout-seconds <n>] [--grace-seconds <n>] -- <command> [args...]
+#
+# Default behavior (no "--"): runs `dotnet test` with the provided args.
+#
+# Exit codes:
+#   0..   Command exit code
+#   124   Timed out
+#   125   Wrapper error / invalid usage
+
+timeout_seconds=60
+grace_seconds=10
+explicit_command=false
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/test-with-timeout.sh [--timeout-seconds <n>] [--grace-seconds <n>] [dotnet-test-args...]
+  scripts/test-with-timeout.sh [--timeout-seconds <n>] [--grace-seconds <n>] -- <command> [args...]
+
+Examples:
+  scripts/test-with-timeout.sh --timeout-seconds 1800 --no-build --configuration Release
+  scripts/test-with-timeout.sh --timeout-seconds 5 -- bash -c 'sleep 30'
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --timeout-seconds)
+      timeout_seconds="${2:-}"
+      shift 2
+      ;;
+    --grace-seconds)
+      grace_seconds="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      explicit_command=true
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ -z "$timeout_seconds" || -z "$grace_seconds" ]]; then
+  usage >&2
+  exit 125
+fi
+
+if ! [[ "$timeout_seconds" =~ ^[0-9]+$ ]] || ! [[ "$grace_seconds" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: timeout and grace must be integers (seconds)." >&2
+  exit 125
+fi
+
+cmd=()
+if [[ "$explicit_command" == "true" ]]; then
+  if [[ ${#@} -eq 0 ]]; then
+    usage >&2
+    exit 125
+  fi
+  cmd=("$@");
+else
+  cmd=(dotnet test "$@")
+fi
+
+if ! command -v "${cmd[0]}" >/dev/null 2>&1; then
+  echo "ERROR: command not found: ${cmd[0]}" >&2
+  exit 125
+fi
+
+# Run the command in its own process group (best-effort), so we can terminate
+# the whole tree if it hangs.
+
+set +e
+if command -v setsid >/dev/null 2>&1; then
+  setsid "${cmd[@]}" &
+else
+  "${cmd[@]}" &
+fi
+pid=$!
+set -e
+
+kill_tree() {
+  local signal="$1"
+
+  # Try process group first; if that fails, fall back to the direct PID.
+  kill -"$signal" -- "-$pid" >/dev/null 2>&1 && return 0
+  kill -"$signal" -- "$pid" >/dev/null 2>&1 && return 0
+
+  return 0
+}
+
+start_epoch="$(date +%s)"
+while kill -0 "$pid" >/dev/null 2>&1; do
+  now_epoch="$(date +%s)"
+  elapsed=$((now_epoch - start_epoch))
+  if (( elapsed >= timeout_seconds )); then
+    echo "ERROR: test command timed out after ${timeout_seconds}s." >&2
+
+    kill_tree TERM
+    sleep "$grace_seconds" || true
+    kill_tree KILL
+
+    wait "$pid" >/dev/null 2>&1 || true
+    exit 124
+  fi
+
+  sleep 1
+done
+
+wait "$pid"
+exit $?

--- a/tests/shell/test_with_timeout_test.sh
+++ b/tests/shell/test_with_timeout_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+chmod +x scripts/test-with-timeout.sh
+
+fail=0
+
+# Test: command should time out
+start="$(date +%s)"
+set +e
+scripts/test-with-timeout.sh --timeout-seconds 1 --grace-seconds 1 -- bash -c 'sleep 10' >/dev/null 2>&1
+rc=$?
+set -e
+end="$(date +%s)"
+elapsed=$((end - start))
+
+if [[ $rc -ne 124 ]]; then
+  echo "ERROR: expected timeout exit code 124, got $rc" >&2
+  fail=1
+else
+  echo "OK: timeout returns 124"
+fi
+
+if (( elapsed > 5 )); then
+  echo "ERROR: timeout took too long (${elapsed}s)" >&2
+  fail=1
+else
+  echo "OK: timeout completes quickly (${elapsed}s)"
+fi
+
+# Test: command exit code is preserved
+set +e
+scripts/test-with-timeout.sh --timeout-seconds 5 -- bash -c 'exit 7' >/dev/null 2>&1
+rc=$?
+set -e
+
+if [[ $rc -ne 7 ]]; then
+  echo "ERROR: expected exit code 7, got $rc" >&2
+  fail=1
+else
+  echo "OK: exit code preserved"
+fi
+
+if [[ $fail -ne 0 ]]; then
+  echo "One or more tests failed." >&2
+  exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary
- Add a portable `scripts/test-with-timeout.sh` wrapper to prevent hung `dotnet test` runs and standardize timeout behavior.
- Wire CI to use the wrapper and add a fast shell test to validate timeout semantics.
- Remove hard-coded `--timeout-seconds 3600` from agent/global docs; prefer wrapper defaults and document override via `--timeout-seconds <seconds>`.

## Verification
- Local `dotnet test` passes (351 tests).
- Shell test: `tests/shell/test_with_timeout_test.sh`.
- Agent validation: `python3 scripts/validate-agents.py`.

## Notes
- Wrapper exits `124` on timeout and preserves the child process exit code otherwise.
- Default timeout is intentionally controlled by the script; documentation avoids pinning a specific number.
