### PR TITLE
docs(workflow): require direct script invocation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,9 +74,10 @@ For project-specific instructions, refer to the `docs/spec.md` file in the repos
 - **Test hangs**: When running the full test suite, use the timeout wrapper instead of calling `dotnet test` directly.
   - Example: `scripts/test-with-timeout.sh -- dotnet test --no-build --configuration Release --verbosity normal`
   - If you need a different timeout: `scripts/test-with-timeout.sh --timeout-seconds <seconds> -- dotnet test ...`
-- **Repo scripts**: Prefer running repository scripts directly (e.g., `scripts/uat-run.sh`, `scripts/pr-github.sh`) instead of `bash scripts/<script>.sh`.
+- **Directly-invokable scripts**: Always run repository scripts directly (e.g., `scripts/uat-run.sh`, `scripts/pr-github.sh`, `scripts/validate-agents.py`) instead of via an interpreter/runner (e.g., `bash scripts/<script>.sh`, `python3 scripts/<script>.py`, `dotnet <runner> scripts/<script>`).
   - This enables per-script permanent allow rules in VS Code approvals.
-  - Exception: use `bash -x scripts/<script>.sh` only for debugging (or if execute bit/shebang is missing).
+  - If a script is not directly invokable, fix it instead of working around it (add a proper shebang and make it executable).
+  - Exception: interpreter tracing is allowed only for debugging (e.g., `bash -x ...`).
 - **Workspace-local temp files**: Do not create or reference temporary files outside the repository (for example `/tmp` or `~/`). If a scratch file is needed, write it under `.tmp/` (create it with `scripts/setup-tmp.sh` if needed).
 - Avoid running commands that are not necessary for the current task.
 - When a command fails, explain the error and propose a solution before retrying.


### PR DESCRIPTION
## Summary
- Tighten the script invocation policy: always invoke repo scripts directly (not via `bash`, `python3`, `dotnet`, etc.).
- Require fixing scripts that aren’t directly runnable (shebang + executable) instead of working around it.
- Keep interpreter tracing allowed for debugging only (e.g., `bash -x ...`).

## Why
Direct invocation enables per-script permanent allow rules in VS Code approvals and reduces repeated prompts.
