### PR TITLE
feat(workflow): add snapshot integrity guardrail

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -38,6 +38,7 @@ Review the implementation thoroughly and produce a Code Review Report that eithe
 - Ensure tests follow naming convention and are meaningful
 - Confirm documentation is updated
 - Check that CHANGELOG.md was NOT modified
+- Treat snapshot changes (`tests/Oocx.TfPlan2Md.Tests/TestData/Snapshots/*.md`) as high-risk and require explicit justification
 - Categorize issues by severity (Blocker/Major/Minor/Suggestion)
 - When reviewing rework from failed PR/CI pipelines, verify the specific failure is resolved
 - For user-facing features affecting markdown rendering, hand off to UAT Tester after code approval
@@ -105,6 +106,7 @@ Before starting, familiarize yourself with:
 - [ ] Tests pass (`scripts/test-with-timeout.sh -- dotnet test`)
 - [ ] No workspace problems (`problems`) after build/test
 - [ ] Docker image builds and feature works in container
+- [ ] If snapshots changed, PR includes `SNAPSHOT_UPDATE_OK` in a commit message and the review notes explain why the diff is correct
 
 ### Code Quality
 - [ ] Follows C# coding conventions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,6 +74,9 @@ For project-specific instructions, refer to the `docs/spec.md` file in the repos
 - **Test hangs**: When running the full test suite, use the timeout wrapper instead of calling `dotnet test` directly.
   - Example: `scripts/test-with-timeout.sh -- dotnet test --no-build --configuration Release --verbosity normal`
   - If you need a different timeout: `scripts/test-with-timeout.sh --timeout-seconds <seconds> -- dotnet test ...`
+- **Snapshot updates**: Snapshot diffs (files under `tests/Oocx.TfPlan2Md.Tests/TestData/Snapshots/`) must be intentional.
+  - Include the token `SNAPSHOT_UPDATE_OK` in at least one commit message in the PR and explain why the snapshot changes are correct.
+  - To regenerate snapshots intentionally, use `scripts/update-test-snapshots.sh`.
 - **Directly-invokable scripts**: Always run repository scripts directly (e.g., `scripts/uat-run.sh`, `scripts/pr-github.sh`, `scripts/validate-agents.py`) instead of via an interpreter/runner (e.g., `bash scripts/<script>.sh`, `python3 scripts/<script>.py`, `dotnet <runner> scripts/<script>`).
   - This enables per-script permanent allow rules in VS Code approvals.
   - If a script is not directly invokable, fix it instead of working around it (add a proper shebang and make it executable).

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -45,9 +45,13 @@ jobs:
             echo "Non-ignored files changed; running validation"
           fi
 
+      - name: Snapshot integrity guardrail
+        if: steps.filter.outputs.changed == 'true'
+        run: scripts/validate-snapshot-changes.sh --base-ref "${{ github.event.pull_request.base.sha }}" --head-ref "${{ github.event.pull_request.head.sha }}"
+
       - name: Shell test (timeout wrapper)
         if: steps.filter.outputs.changed == 'true'
-        run: bash tests/shell/test_with_timeout_test.sh
+        run: tests/shell/test_with_timeout_test.sh
 
       - name: Setup .NET
         if: steps.filter.outputs.changed == 'true'
@@ -69,9 +73,7 @@ jobs:
 
       - name: Test
         if: steps.filter.outputs.changed == 'true'
-        run: |
-          chmod +x scripts/test-with-timeout.sh
-          scripts/test-with-timeout.sh --timeout-seconds 3600 -- dotnet test --no-build --configuration Release --verbosity normal
+        run: scripts/test-with-timeout.sh -- dotnet test --no-build --configuration Release --verbosity normal
 
       - name: Setup Node
         if: steps.filter.outputs.changed == 'true'

--- a/scripts/validate-snapshot-changes.sh
+++ b/scripts/validate-snapshot-changes.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate Snapshot Changes
+#
+# Fails when snapshot files change without an explicit commit-message token.
+#
+# Token: SNAPSHOT_UPDATE_OK
+#
+# Usage (local):
+#   scripts/validate-snapshot-changes.sh
+#
+# Usage (CI):
+#   scripts/validate-snapshot-changes.sh --base-ref "origin/${GITHUB_BASE_REF}" --head-ref "${GITHUB_SHA}"
+
+TOKEN="SNAPSHOT_UPDATE_OK"
+SNAPSHOT_PATH_PREFIX="tests/Oocx.TfPlan2Md.Tests/TestData/Snapshots/"
+
+cd "$(git rev-parse --show-toplevel)"
+
+base_ref=""
+head_ref=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-ref)
+      base_ref="$2"
+      shift 2
+      ;;
+    --head-ref)
+      head_ref="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$head_ref" ]]; then
+  head_ref="HEAD"
+fi
+
+if [[ -z "$base_ref" ]]; then
+  if git show-ref --verify --quiet refs/remotes/origin/main; then
+    base_ref="origin/main"
+  else
+    base_ref="main"
+  fi
+fi
+
+merge_base="$(git merge-base "$base_ref" "$head_ref")"
+
+changed_files="$(git diff --name-only "$merge_base".."$head_ref" || true)"
+
+if [[ -z "$changed_files" ]]; then
+  exit 0
+fi
+
+snapshot_changed="false"
+while IFS= read -r file; do
+  if [[ "$file" == ${SNAPSHOT_PATH_PREFIX}* ]]; then
+    snapshot_changed="true"
+    break
+  fi
+done <<< "$changed_files"
+
+if [[ "$snapshot_changed" != "true" ]]; then
+  exit 0
+fi
+
+commit_messages="$(git log --format=%B "$merge_base".."$head_ref")"
+
+if grep -Fq "$TOKEN" <<< "$commit_messages"; then
+  exit 0
+fi
+
+echo "ERROR: Snapshot files changed, but no allow token was found in commit messages." >&2
+echo "" >&2
+echo "Snapshot path: ${SNAPSHOT_PATH_PREFIX}" >&2
+echo "Required token (add to at least one commit message in this PR): ${TOKEN}" >&2
+echo "" >&2
+echo "Why: Snapshot updates must be intentional and explicitly justified." >&2
+exit 1


### PR DESCRIPTION
## Summary
- Add `scripts/validate-snapshot-changes.sh` to block snapshot diffs unless explicitly allowed.
- Enforce the allow rule in PR Validation before expensive build/test steps.
- Document snapshot update policy in `.github/copilot-instructions.md` and require Code Reviewer to justify snapshot diffs.

## Policy
- Snapshot path: `tests/Oocx.TfPlan2Md.Tests/TestData/Snapshots/*.md`
- Required allow token in commit message: `SNAPSHOT_UPDATE_OK`

## Why
Snapshot changes are high-risk: they can hide regressions or accidental rendering changes. This guardrail makes updates explicit and reviewable.
