### PR TITLE
fix(workflow): retro metrics plausibility and no-guess policy

### DIFF
--- a/.github/agents/retrospective.agent.md
+++ b/.github/agents/retrospective.agent.md
@@ -32,6 +32,9 @@ Identify improvement opportunities for the development workflow by analyzing the
 - Encourage the user to be honest and constructive about what went well and what didn't.
 - Focus on *process* improvements (how we work), not just code improvements.
 - Use the "Draft Notes" section of the retrospective file to log issues raised during development.
+- Include a **verbatim** section with all user feedback that mentions the retrospective (e.g., "note for retro: ...", "retrospective: ...") from the chat export and from the interactive phase.
+- Always ask: **"Any other issues you want to add?"** (wait for an answer before finalizing the report).
+- Ensure every user feedback item results in at least one **documented improvement opportunity** in the report (with where + verification).
 
 ⚠️ **Ask First:**
 - Before overwriting an existing finalized retrospective report.
@@ -41,6 +44,7 @@ Identify improvement opportunities for the development workflow by analyzing the
 - Modify code, tests, documentation, or other agents' artifacts — handoff to the appropriate agent instead (Developer for code, Technical Writer for docs, etc.).
 - Allow the retrospective file to be overwritten by other agents (only Retrospective agent owns `retrospective.md`).
 - Commit chat logs without first scanning and redacting sensitive information (passwords, tokens, API keys, secrets, PII).
+- Guess missing information from the chat export (especially **which custom agent** produced a message, or per-agent time splits). If the export does not contain it, mark it as **Unavailable** and move on.
 
 ## Response Style
 
@@ -109,12 +113,12 @@ When the user invokes you after a release to conduct the retrospective:
 2.  **Analyze Chat Log** (use `analyze-chat-export` skill):
     *   Run the jq extraction queries from the skill to gather:
         *   Session metrics (duration, total requests)
-        *   **Model usage by agent** (which models each agent used)
-        *   **Request counts by agent and model**
-        *   **Automation effectiveness by agent** (manual vs auto approvals)
+        *   **Model usage** (overall)
+        *   **Request counts by model**
+        *   **Automation effectiveness** (overall)
         *   **Rejection analysis** (cancelled requests, failed requests, tool rejections)
         *   **File edit statistics** (kept vs undone/rejected edits)
-        *   **Tool usage by agent**
+        *   **Tool usage** (overall)
         *   **Terminal command patterns** (candidates for script automation)
         *   **Model performance statistics** (response times, success rates)
     *   Identify patterns indicating workflow issues: repeated attempts, errors, confusion, tool failures, boundary violations.
@@ -132,10 +136,10 @@ When the user invokes you after a release to conduct the retrospective:
         *   Session duration
         *   User wait time (time spent waiting for user confirmation)
         *   Agent work time (cumulative response generation time)
-    *   **Request Counts by Agent**: How many requests each agent handled.
-    *   **Model Usage by Agent**: Which models each agent used and how often.
-    *   **Automation Effectiveness by Agent**: Auto vs manual approvals, automation rate percentage.
-    *   **Tool Usage by Agent**: Which tools each agent used most.
+    *   **Agent-level breakdown (CONDITIONAL):** Only include per-agent metrics if the chat export includes reliable agent identifiers. Otherwise, explicitly mark these as **Unavailable** and do not guess.
+    *   **Model Usage**: Which models were used and how often.
+    *   **Automation Effectiveness**: Auto vs manual approvals, automation rate percentage.
+    *   **Tool Usage**: Which tools were used most.
     *   **Model Performance**: Average response time and success rate by model.
     *   **Rejection Analysis**:
         *   Rejections grouped by agent (cancelled, failed, tool rejections)
@@ -167,10 +171,9 @@ When the user invokes you after a release to conduct the retrospective:
             *   Time breakdown table (session duration, user wait time, agent work time with percentages)
             *   Start/end timestamps, total requests, files changed, tests
         *   **Agent Analysis** (REQUIRED):
-            *   Model usage by agent table
-            *   Request counts by agent and model
-            *   Automation effectiveness by agent (with automation rate %)
-            *   Tool usage by agent
+            *   **Agent attribution note**: state whether per-agent metrics are available.
+            *   If available: model usage by agent, request counts by agent, automation effectiveness by agent, tool usage by agent.
+            *   If unavailable: omit per-agent tables and provide overall metrics instead.
         *   **Rejection Analysis** (REQUIRED):
             *   Rejections by agent (cancelled, failed, tool rejections, rejection rate)
             *   Rejections by model
@@ -185,6 +188,10 @@ When the user invokes you after a release to conduct the retrospective:
         *   **What Went Well**: Successes to repeat — cite examples from chat log.
         *   **What Didn't Go Well**: Issues encountered — cite examples from chat log.
         *   **Improvement Opportunities**: Concrete, actionable recommendations derived from chat log analysis.
+        *   **User Feedback (verbatim)** (REQUIRED):
+            *   All feedback from the chat export that mentions the retrospective
+            *   All feedback given during the interactive phase
+            *   Each feedback item must map to at least one improvement opportunity (explicit mapping)
         *   **CI / Status Checks Summary** (when applicable):
             *   CI pass/fail outcome(s) and timestamps
             *   Any reruns and their reason (if known)
@@ -192,6 +199,8 @@ When the user invokes you after a release to conduct the retrospective:
         *   **Retrospective DoD Checklist** (REQUIRED):
             *   A short checklist confirming all required evidence sources, sections, and metrics are present.
             *   Include an explicit “No unsupported claims” check.
+            *   Include an explicit “No guessed agent attribution” check.
+            *   Include an explicit “All retro-related user feedback captured verbatim” check.
 8.  **Action Items**:
     *   For each improvement opportunity, suggest a specific action (e.g., "Update `docs/agents.md`", "Modify Developer agent prompt").
     *   **Action-item format (REQUIRED):** Every action item must include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ jobs:
           persist-credentials: true
 
       - name: Shell test (timeout wrapper)
-        run: bash tests/shell/test_with_timeout_test.sh
+        run: tests/shell/test_with_timeout_test.sh
+
+      - name: Shell test (analyze chat)
+        run: tests/shell/analyze_chat_test.sh
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -53,6 +53,10 @@ jobs:
         if: steps.filter.outputs.changed == 'true'
         run: tests/shell/test_with_timeout_test.sh
 
+      - name: Shell test (analyze chat)
+        if: steps.filter.outputs.changed == 'true'
+        run: tests/shell/analyze_chat_test.sh
+
       - name: Setup .NET
         if: steps.filter.outputs.changed == 'true'
         uses: actions/setup-dotnet@v5

--- a/tests/shell/analyze_chat_test.sh
+++ b/tests/shell/analyze_chat_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+chmod +x scripts/analyze-chat.py
+
+output="$(scripts/analyze-chat.py tests/shell/testdata/chat-minimal.json)"
+
+echo "$output" | grep -q "Agent Attribution:" || {
+  echo "ERROR: expected Agent Attribution section" >&2
+  exit 1
+}
+
+echo "$output" | grep -q "per-agent metrics are not reported" || {
+  echo "ERROR: expected explicit 'per-agent metrics are not reported' note" >&2
+  exit 1
+}
+
+echo "$output" | grep -q "Retrospective Feedback (verbatim):" || {
+  echo "ERROR: expected Retrospective Feedback section" >&2
+  exit 1
+}
+
+echo "$output" | grep -q "note for retro" || {
+  echo "ERROR: expected retro feedback to be included verbatim" >&2
+  exit 1
+}
+
+echo "$output" | grep -q "Plausibility Warnings:" || {
+  echo "ERROR: expected Plausibility Warnings section" >&2
+  exit 1
+}
+
+echo "OK: analyze-chat.py outputs attribution note, feedback, and warnings"

--- a/tests/shell/testdata/chat-minimal.json
+++ b/tests/shell/testdata/chat-minimal.json
@@ -1,0 +1,26 @@
+{
+  "initialLocation": "panel",
+  "responderUsername": "Copilot",
+  "requests": [
+    {
+      "requestId": "1",
+      "timestamp": 1700000000000,
+      "timeSpentWaiting": 0,
+      "modelId": "copilot/gpt-5.1-codex-max",
+      "message": {"text": "note for retro: wrong user time / agent time"},
+      "response": [],
+      "modelState": {"value": 1},
+      "result": {"timings": {"totalElapsed": 1000}}
+    },
+    {
+      "requestId": "2",
+      "timestamp": 1700000005000,
+      "timeSpentWaiting": 2000,
+      "modelId": "copilot/gemini-3-flash-preview",
+      "message": {"text": "retrospective: missed user feedback"},
+      "response": [],
+      "modelState": {"value": 2},
+      "result": {"timings": {"totalElapsed": 500}}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Stops `scripts/analyze-chat.py` from guessing which custom agent produced messages (chat exports don't reliably include that data).
- Adds explicit attribution disclaimer, richer plausibility warnings, and verbatim extraction of retro-related user feedback.
- Updates the Retrospective agent to forbid guessing missing info, always ask for additional issues, and require verbatim feedback + mapped improvement opportunities.
- Adds a shell test for `scripts/analyze-chat.py` and wires it into PR Validation + CI.

## Why
Retrospectives previously produced incorrect per-agent statistics (user time vs agent time, message counts, model usage) due to heuristic guessing. This change makes the workflow evidence-based and prevents hallucinated/unsupported metrics.

## Verification
- `tests/shell/analyze_chat_test.sh`
- `tests/shell/test_with_timeout_test.sh`
- `scripts/validate-agents.py`
