### PR TITLE
fix(agents): remove notebook tool references

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -3,7 +3,7 @@ description: Review code for quality, standards, and correctness
 name: Code Reviewer
 target: vscode
 model: Claude Sonnet 4.5
-tools: ['search', 'edit/createFile', 'edit/editFiles', 'execute/runInTerminal', 'execute/runTests', 'execute/testFailure', 'read/problems', 'search/changes', 'read/readFile', 'search/listDirectory', 'search/codebase', 'search/usages', 'read/terminalLastCommand', 'execute/getTerminalOutput', 'github/*', 'microsoftdocs/mcp/*', 'io.github.hashicorp/terraform-mcp-server/*', 'ms-toolsai.jupyter/*', 'copilot-container-tools/*', 'todo']
+tools: ['search', 'edit/createFile', 'edit/editFiles', 'execute/runInTerminal', 'execute/runTests', 'execute/testFailure', 'read/problems', 'search/changes', 'read/readFile', 'search/listDirectory', 'search/codebase', 'search/usages', 'read/terminalLastCommand', 'execute/getTerminalOutput', 'github/*', 'microsoftdocs/mcp/*', 'io.github.hashicorp/terraform-mcp-server/*', 'copilot-container-tools/*', 'todo']
 handoffs:
   - label: Request Rework
     agent: "Developer"

--- a/.github/agents/workflow-engineer.agent.md
+++ b/.github/agents/workflow-engineer.agent.md
@@ -3,7 +3,7 @@ description: Analyze, improve, and maintain the agent workflow
 name: Workflow Engineer
 target: vscode
 model: GPT-5.2
-tools: ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'copilot-container-tools/*', 'github/*', 'io.github.hashicorp/terraform-mcp-server/*', 'mcp-mermaid/*', 'memory/*', 'microsoftdocs/mcp/*', 'agent', 'github.vscode-pull-request-github/copilotCodingAgent', 'github.vscode-pull-request-github/issue_fetch', 'github.vscode-pull-request-github/suggest-fix', 'github.vscode-pull-request-github/searchSyntax', 'github.vscode-pull-request-github/doSearch', 'github.vscode-pull-request-github/renderIssues', 'github.vscode-pull-request-github/activePullRequest', 'github.vscode-pull-request-github/openPullRequest', 'ms-toolsai.jupyter/configureNotebook', 'ms-toolsai.jupyter/listNotebookPackages', 'ms-toolsai.jupyter/installNotebookPackages', 'todo']
+tools: ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'copilot-container-tools/*', 'github/*', 'io.github.hashicorp/terraform-mcp-server/*', 'mcp-mermaid/*', 'memory/*', 'microsoftdocs/mcp/*', 'agent', 'github.vscode-pull-request-github/copilotCodingAgent', 'github.vscode-pull-request-github/issue_fetch', 'github.vscode-pull-request-github/suggest-fix', 'github.vscode-pull-request-github/searchSyntax', 'github.vscode-pull-request-github/doSearch', 'github.vscode-pull-request-github/renderIssues', 'github.vscode-pull-request-github/activePullRequest', 'github.vscode-pull-request-github/openPullRequest', 'todo']
 ---
 
 # Workflow Engineer Agent


### PR DESCRIPTION
## Summary
Removes Jupyter notebook tool references from agent definitions now that the VS Code Jupyter extension is no longer used in this workflow.

## Change
- Updates .github/agents/workflow-engineer.agent.md to remove `ms-toolsai.jupyter/*` tool references.
- Updates .github/agents/code-reviewer.agent.md to remove `ms-toolsai.jupyter/*` tool references.

## Verification
- Ran scripts/validate-agents.py
