### PR TITLE
feat(workflow): add website memory backlog

### DIFF
--- a/.github/agents/web-designer.agent.md
+++ b/.github/agents/web-designer.agent.md
@@ -3,7 +3,7 @@ description: Design, develop, and maintain the tfplan2md website
 name: Web Designer
 target: vscode
 model: Claude Sonnet 4.5
-tools: ['execute/runInTerminal', 'read/readFile', 'read/problems', 'edit', 'search', 'github/*', 'todo']
+tools: ['execute/runInTerminal', 'read/readFile', 'read/problems', 'edit', 'search', 'web', 'io.github.chromedevtools/chrome-devtools-mcp/*', 'github/*', 'todo']
 handoffs:
   - label: Create Pull Request
     agent: "Release Manager"
@@ -86,7 +86,13 @@ Todo lists:
 ## Context to Read
 
 Before starting, familiarize yourself with:
-- [docs/features/025-github-pages-website/specification.md](../../docs/features/025-github-pages-website/specification.md) - Website requirements and page structure
+- [website/_memory/site-structure.md](../../website/_memory/site-structure.md) - Source of truth for current site map + per-page intent + decision log
+- [website/_memory/backlog.md](../../website/_memory/backlog.md) - Source of truth for open website work items and status
+- [website/_memory/feature-definitions.md](../../website/_memory/feature-definitions.md) - Source of truth for feature grouping + icon/image assignment
+- [website/_memory/style-guide.md](../../website/_memory/style-guide.md) - Source of truth for design/style decisions
+- [website/_memory/non-functional-requirements.md](../../website/_memory/non-functional-requirements.md) - Source of truth for NFRs (accessibility, browser support, etc.)
+- [website/_memory/screenshots.md](../../website/_memory/screenshots.md) - Source of truth for screenshots used on the site + generation commands
+- [website/_memory/code-examples.md](../../website/_memory/code-examples.md) - Source of truth for code examples used on the site + generation commands
 - [README.md](../../README.md) - Source for homepage content and feature descriptions
 - [docs/features.md](../../docs/features.md) - Detailed feature descriptions for feature pages
 - [docs/spec.md](../../docs/spec.md) - Project overview and technical details
@@ -95,6 +101,34 @@ Before starting, familiarize yourself with:
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) - Contribution guidelines for /contributing page
 - [examples/comprehensive-demo/](../../examples/comprehensive-demo/) - Source for screenshots and examples
 - [.github/copilot-instructions.md](../.github/copilot-instructions.md) - Project-wide guidelines
+
+## Website Memory Docs (CRITICAL)
+
+The following files under `website/_memory/` are mandatory “memory” for website decisions:
+
+- `feature-definitions.md`: feature grouping, value, and unique icon/image assignment
+- `site-structure.md`: current site map, per-page purpose, outbound links, and decision log
+- `backlog.md`: open website tasks backlog and status tracking
+- `style-guide.md`: design/style decisions the site must follow
+- `non-functional-requirements.md`: accessibility and other quality constraints
+- `screenshots.md`: screenshot inventory and exact generation commands
+- `code-examples.md`: code example inventory and exact generation commands
+
+Backlog rules:
+- Add new work to `website/_memory/backlog.md` before starting implementation.
+- Keep `Status` updated as work progresses.
+- Do not delete backlog items; close them by marking `✅ Done`.
+
+When you change website content, structure, or design decisions:
+- Update the relevant `website/_memory/*` documents in the same PR.
+
+## Agent Skills to Use
+
+Use these skills while working on the website:
+
+- `website-visual-assets` — generate HTML exports + screenshots and keep `website/_memory/screenshots.md` up to date
+- `website-devtools` — use Chrome DevTools MCP tools to inspect rendering and troubleshoot issues with the Maintainer
+- `website-quality-check` — run a repeatable quality checklist, including verifying adherence to the style guide
 
 ## Website Requirements
 

--- a/.github/skills/website-devtools/SKILL.md
+++ b/.github/skills/website-devtools/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: website-devtools
+description: Use Chrome DevTools MCP tools to inspect rendering and troubleshoot website issues with the Maintainer.
+---
+
+# Skill Instructions
+
+## Purpose
+Provide a repeatable way to use Chrome DevTools during website work to validate rendering, diagnose layout/CSS issues, and troubleshoot together with the Maintainer.
+
+## Hard Rules
+### Must
+- [ ] Use `io.github.chromedevtools/chrome-devtools-mcp/*` tools when diagnosing rendering/layout issues.
+- [ ] Capture concrete findings (console errors, computed styles, DOM structure) and summarize them in the PR/issue.
+
+### Must Not
+- [ ] Do not guess at rendering behavior when you can verify it using DevTools.
+
+## Golden Example
+
+```text
+Use Chrome DevTools MCP tools to:
+- Inspect computed styles and layout for a problematic element
+- Check console for errors
+- Verify responsive behavior by simulating viewports
+```
+
+## Actions
+1. Open or serve the website locally (if needed) so it can be inspected.
+2. Use Chrome DevTools MCP tools to inspect:
+   - DOM structure and element attributes
+   - Computed CSS and layout metrics
+   - Console logs and runtime errors
+   - Network requests (if applicable)
+3. Share findings with the Maintainer and propose the smallest fix.

--- a/.github/skills/website-quality-check/SKILL.md
+++ b/.github/skills/website-quality-check/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: website-quality-check
+description: Run a lightweight, repeatable quality checklist for the website (including style guide adherence).
+---
+
+# Skill Instructions
+
+## Purpose
+Provide a lightweight, repeatable quality checklist for website changes.
+
+## Hard Rules
+### Must
+- [ ] Verify the change follows `website/_memory/style-guide.md`.
+- [ ] Verify the change follows `website/_memory/non-functional-requirements.md`.
+- [ ] Do quick link/navigation sanity checks on changed pages.
+- [ ] Do basic accessibility spot checks (headings, aria labels, keyboard navigation where relevant).
+
+### Must Not
+- [ ] Do not merge or hand off for PR without completing the checklist for the changed pages.
+
+## Golden Example
+
+```text
+Checklist (per changed page):
+- Style guide: containers, typography, nav consistency
+- NFRs: accessibility basics, supported browsers
+- Links: no broken relative links introduced
+- DevTools: verify layout and console is clean
+```
+
+## Actions
+1. Identify which pages/assets changed under `website/`.
+2. For each changed page, verify:
+   - Style guide adherence (`website/_memory/style-guide.md`)
+   - NFR adherence (`website/_memory/non-functional-requirements.md`)
+   - Link/navigation sanity
+   - Accessibility basics
+3. If issues are found, fix them or record them with a clear plan.

--- a/.github/skills/website-visual-assets/SKILL.md
+++ b/.github/skills/website-visual-assets/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: website-visual-assets
+description: Generate website HTML exports and screenshots using the repo's HtmlRenderer and ScreenshotGenerator tools.
+---
+
+# Skill Instructions
+
+## Purpose
+Provide a repeatable workflow to generate HTML exports and screenshots for the website, and keep the screenshot inventory in sync.
+
+## Hard Rules
+### Must
+- [ ] Use `tools/Oocx.TfPlan2Md.HtmlRenderer` to generate HTML from markdown reports.
+- [ ] Use `tools/Oocx.TfPlan2Md.ScreenshotGenerator` (Playwright) to generate screenshots from those HTML exports.
+- [ ] Store website screenshots under `website/assets/screenshots/`.
+- [ ] Add/update an entry in `website/_memory/screenshots.md` for every screenshot used by the website.
+
+### Must Not
+- [ ] Do not hand-edit screenshots or create “mock” screenshots that aren’t generated from real HTML exports.
+
+## Golden Example
+
+```bash
+# 1) Generate HTML (GitHub flavor)
+dotnet run --project tools/Oocx.TfPlan2Md.HtmlRenderer -- \
+  --input artifacts/comprehensive-demo.md \
+  --flavor github
+
+# 2) Generate HTML (Azure DevOps flavor, wrapped)
+dotnet run --project tools/Oocx.TfPlan2Md.HtmlRenderer -- \
+  --input artifacts/comprehensive-demo.md \
+  --flavor azdo \
+  --template tools/Oocx.TfPlan2Md.HtmlRenderer/templates/azdo-wrapper.html \
+  --output artifacts/comprehensive-demo.azdo.html
+
+# 3) Capture a screenshot
+DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 dotnet run --project tools/Oocx.TfPlan2Md.ScreenshotGenerator -- \
+  --input artifacts/comprehensive-demo.azdo.html \
+  --output website/assets/screenshots/full-report-azdo.png \
+  --full-page
+```
+
+## Actions
+1. Pick the markdown report under `artifacts/` to use as the source.
+2. Generate the required HTML exports with `tools/Oocx.TfPlan2Md.HtmlRenderer`.
+3. Generate screenshots from the exported HTML with `tools/Oocx.TfPlan2Md.ScreenshotGenerator`.
+4. Add/update `website/_memory/screenshots.md` with:
+   - Screenshot file name
+   - Exact commands used
+   - Intended purpose (where it is used on the website)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -95,6 +95,9 @@ Format:
 | `watch-uat-github-pr` | Watch a GitHub UAT PR for maintainer feedback or approval by polling comments until approved/passed. |
 | `watch-uat-azdo-pr` | Watch an Azure DevOps UAT PR for maintainer feedback or approval by polling threads and reviewer votes until approved/passed. |
 | `analyze-chat-export` | Extract metrics from VS Code Copilot chat exports for retrospective analysis (model usage, tool invocations, approvals, timing). |
+| `website-devtools` | Use Chrome DevTools MCP tools to inspect rendering and troubleshoot website issues with the Maintainer. |
+| `website-quality-check` | Run a lightweight, repeatable website quality checklist (including style guide adherence). |
+| `website-visual-assets` | Generate website HTML exports and screenshots using HtmlRenderer/ScreenshotGenerator; keep inventories in sync. |
 | `validate-agent` | Validate agent definitions for consistency, model availability, handoff integrity, and tool existence. |
 
 ### Prefer GitHub Chat Tools For PR Inspection

--- a/docs/workflow/029-web-designer-agent-memory-docs/plan.md
+++ b/docs/workflow/029-web-designer-agent-memory-docs/plan.md
@@ -1,0 +1,370 @@
+# Plan: Improve Web Designer agent with website memory docs + screenshot inventory
+
+**Date:** 2026-01-03
+
+## Verbatim requirements (Maintainer)
+
+> I want to improve the web-designer agent.
+>
+> 1) in 025, we created a table of all features and classified how we want to represent them on the web site (value, group). Copy this table so somewhere in the website directory. I want to create a list of files like this that must be used by the web design agent as memory for decisions on the website content. Update the agent to use these files.
+>
+> 2) as part of these files, I also want to store the planned web site structure. The document must include the hierarchical structure of the web site. For each individual site, the document must describe the title, purpose, content summary, target audience, and list of links to which other sites this site ilnks to. It must also be used as log for each site to note decisions we made on content, design or structure of each page. Update the agents instructions on how to use this document.
+>
+> 3) we created new html export and screnshot tools. The html export can generate html from markdown reports and supports github and azure devops profiles. the screenshot tool can generate a screenshot based on that html export and also supports azdo and gh profiles. The web-design agent must use these tools to generate all screenthos and html exports it needs as examples or to showcase features on the web site. It must keep a list of screenshots it uses as markdown document. This document must contain the screenshot file name, explain how to generate the screenshot (exact tool usage), and describe the indended purpose of the screenshot.
+
+## Current context (what already exists)
+
+- Feature categorization table exists in: `docs/features/025-github-pages-website/feature-definitions.md`.
+- Website content currently lives in: `website/` (today it contains `style.css` and `features/index.html`).
+- Web Designer agent exists in: `.github/agents/web-designer.agent.md`.
+- Dev tools exist and have documented CLI usage:
+  - HTML renderer: `dotnet run --project tools/Oocx.TfPlan2Md.HtmlRenderer -- ...` (supports `--flavor github|azdo`).
+  - Screenshot generator: `dotnet run --project tools/Oocx.TfPlan2Md.ScreenshotGenerator -- ...` (captures from the HTML output; supports targets).
+
+## Design goals for the change
+
+- Put “website content decisions” into explicit, versioned docs under `website/` so the Web Designer agent can treat them as source-of-truth memory.
+- Keep the memory docs:
+  - Small, navigable, and easy to update in PRs.
+  - Explicit about “what we decided” vs “what we might do later”.
+- Make screenshot + HTML example generation reproducible via exact commands.
+- Ensure non-functional requirements (especially accessibility) are explicit and enforced.
+- Ensure design/style decisions are recorded and consistently applied.
+
+## Proposed new website memory files (source of truth)
+
+Create a dedicated directory under `website/`:
+
+- `website/_memory/` (new)
+  - Purpose: source-of-truth “memory” docs for website content, structure, and examples.
+  - Rationale: keeps the memory next to the site, avoids scattering decisions across `docs/`.
+
+### File 1: Feature representation table (copy from 025)
+
+- `website/_memory/feature-definitions.md`
+  - Content: copy the “Complete Feature Table” (and relevant headings) from `docs/features/025-github-pages-website/feature-definitions.md`.
+  - Required table columns:
+    - `Feature`
+    - `Description`
+    - `Group`
+    - `Value`
+    - `Icon/Image` (new)
+      - Must reference the icon/image used to represent the feature on the website (e.g., an asset filename/path).
+      - Uniqueness rule: different features may not use the same icon/image.
+  - Maintenance rule: when features are reclassified (Value/Group) or their icon/image changes, update this file and use it to drive which pages exist, what gets highlighted, and which visuals are used.
+
+### File 2: Website structure + per-page decision log
+
+- `website/_memory/site-structure.md`
+  - Must include:
+    - A hierarchical site map.
+    - For each page ("individual site"):
+      - Title
+      - Purpose
+      - Content summary
+      - Target audience
+      - Links to other pages (outbound links)
+      - Decision log (dated entries) for content/design/structure decisions.
+
+Initial structure rule (important):
+
+- The initial site map and page list must be derived from the pages that exist in `website/` at the time of creation.
+- Planned/future pages may be captured separately (e.g., a “Planned additions” section), but must be clearly marked as planned and must not be mixed into the “current site map”.
+
+Recommended format (so it stays consistent):
+
+- Top section: a tree like:
+  - `/` (index)
+  - `/features/` (index)
+  - `/features/<feature>.html`
+  - …
+
+- Then one page spec block per page:
+  - `## /features/index.html`
+    - **Title:** ...
+    - **Purpose:** ...
+    - **Content summary:** ...
+    - **Target audience:** ...
+    - **Links to:**
+      - ...
+    - **Decision log:**
+      - 2026-01-03: ...
+
+Note: The decision log should record outcomes only (not long discussions), so it stays usable as memory.
+
+### File 3: Screenshot inventory (with exact tool usage)
+
+- `website/_memory/screenshots.md`
+  - Must contain, per screenshot:
+    - Screenshot file name (and where it lives in `website/`)
+    - Exact commands to generate it (including both HTML export and screenshot capture)
+    - Intended purpose (where it’s used / what feature it demonstrates)
+
+Recommended conventions:
+
+- Store images under `website/assets/screenshots/` (new directory).
+- Use deterministic, descriptive filenames (e.g., `semantic-diff-azdo.png`, `nsg-rules-table-azdo.png`).
+- Keep the inventory as the definitive list of “approved” screenshots used in the website.
+
+## Plan: skills vs Web Designer agent instructions
+
+### Skills to add
+
+1) Visual asset generation workflow (HTML export + screenshots)
+
+- Skill: `.github/skills/website-visual-assets/`
+
+2) Chrome DevTools-based troubleshooting / rendering analysis
+
+- Skill: `.github/skills/website-devtools/`
+
+3) Website quality checks (local verification workflow)
+
+- Skill: `.github/skills/website-quality-check/`
+  - Scope: lightweight, repeatable checks the Web Designer should run while working on the site.
+  - Examples of what it covers (keep minimal):
+    - Local preview workflow
+    - Link/navigation sanity checks
+    - Accessibility spot checks
+    - Check that the site follows `website/_memory/style-guide.md`
+    - How to use DevTools to validate rendering and capture findings
+
+### Keep as Web Designer agent instructions + website memory docs
+
+1) Memory docs policy and content requirements
+
+- `.github/agents/web-designer.agent.md` must require reading and updating `website/_memory/*`.
+
+2) Style guide and NFRs
+
+- Memory docs:
+  - `website/_memory/style-guide.md`
+  - `website/_memory/non-functional-requirements.md`
+- Enforcement stays in `.github/agents/web-designer.agent.md`.
+
+3) Code examples inventory
+
+- Memory doc: `website/_memory/code-examples.md`
+- Enforcement stays in `.github/agents/web-designer.agent.md`.
+
+4) Feature icon/image consistency
+
+- Memory doc: `website/_memory/feature-definitions.md` (via the required `Icon/Image` column)
+- Enforcement stays in `.github/agents/web-designer.agent.md` (must keep icons consistent and unique across features).
+
+### File 4: Website style guide (design decisions)
+
+- `website/_memory/style-guide.md`
+  - Purpose: capture and enforce important design and style decisions.
+  - Must include (at minimum):
+    - Typography rules (headings/body sizing, spacing conventions)
+    - Layout rules (page width constraints, grid patterns, spacing rhythm)
+    - Component patterns used in the site (e.g., “feature cards”, “callout blocks”)
+    - Image/screenshot usage rules (sizes/aspect ratios, captions, alt text style)
+    - Decision log (dated) for changes to the style guide
+  - Rule: the Web Designer must follow this guide when working on the site, and update it when decisions change.
+
+### File 5: Non-functional requirements (NFRs)
+
+- `website/_memory/non-functional-requirements.md`
+  - Purpose: make NFRs explicit, testable, and easy to reference.
+  - Must include (at minimum):
+    - Accessibility: the website must be fully accessible (keep the accessibility requirements here as the canonical list).
+    - Browser support: support only the latest version of Edge and Firefox.
+    - Standards: usage of modern standards and features (HTML/CSS/JS) is encouraged, assuming they are supported by the supported browsers.
+    - Performance / maintainability constraints (keep scope minimal unless explicitly expanded).
+
+### File 6: Code examples inventory (with generation instructions)
+
+- `website/_memory/code-examples.md`
+  - Purpose: the definitive list of code examples/snippets shown on the website.
+  - Must contain, per code example:
+    - A stable identifier or name
+    - Where it is used on the website (page + section)
+    - Source-of-truth location in the repo (file path)
+    - How to (re)generate or refresh it
+      - If generated by tooling: exact command(s)
+      - If maintained manually: an explicit procedure (and the canonical source to copy from)
+    - Intended purpose (what user problem it addresses)
+
+## Required Web Designer agent updates
+
+Update `.github/agents/web-designer.agent.md` so the agent:
+
+### 1) Treats website memory docs as mandatory context
+
+- Add `website/_memory/feature-definitions.md` to “Context to Read”.
+- Add `website/_memory/site-structure.md` to “Context to Read”.
+- Add `website/_memory/screenshots.md` to “Context to Read”.
+- Add `website/_memory/style-guide.md` to “Context to Read”.
+- Add `website/_memory/non-functional-requirements.md` to “Context to Read”.
+- Add `website/_memory/code-examples.md` to “Context to Read”.
+
+Add an explicit instruction block like:
+
+- When making website decisions (content, layout, page list), the agent must:
+  1. Read the memory docs.
+  2. Apply changes consistent with them.
+  3. Update the memory docs in the same PR when decisions change.
+
+### 2) Define how to use the site structure doc
+
+Add instructions that the agent must:
+
+- Use `website/_memory/site-structure.md` as the single source of truth for:
+  - Which pages exist.
+  - Page purpose and content boundaries.
+  - Navigation/outbound links.
+- Record decisions in the per-page “Decision log” section whenever:
+  - A page title/purpose changes.
+  - A page is added/removed/renamed.
+  - Major content is added/removed.
+
+### 3) Require HTML renderer + screenshot generator usage for visuals
+
+Add instructions that the agent must:
+
+- Generate all showcased HTML exports using the HTML renderer tool (no hand-written HTML “mock” screenshots).
+- Generate all showcased screenshots using the screenshot generator tool (Playwright), driven by the exported HTML.
+- Maintain `website/_memory/screenshots.md` as the authoritative inventory of screenshots used.
+
+Include the exact commands (documented in repo) in the agent as canonical patterns.
+
+### 4) Require a style guide and NFR compliance
+
+Add instructions that the agent must:
+
+- Treat `website/_memory/style-guide.md` as the canonical source for visual/design decisions.
+- Treat `website/_memory/non-functional-requirements.md` as the canonical source for quality constraints.
+- Keep both documents updated when decisions change (dated decision log entries).
+
+### 5) Require code examples inventory
+
+Add instructions that the agent must:
+
+- Keep `website/_memory/code-examples.md` up to date with every code snippet added/removed/changed on the website.
+- Prefer examples sourced from existing documentation (README.md, docs/) unless explicitly instructed otherwise.
+- When an example is generated (e.g., report output), record the exact command(s) that produce it.
+
+### 6) Require Chrome DevTools MCP usage during website work
+
+Add instructions that the agent must:
+
+- Be configured with the Chrome DevTools MCP tool set: `io.github.chromedevtools/chrome-devtools-mcp/*`.
+- Use the Chrome DevTools tools while working on the website to:
+  - Analyze how pages render (DOM/CSS/layout) and confirm expected behavior.
+  - Troubleshoot issues together with the Maintainer (e.g., reproduce and inspect a rendering issue).
+
+Note: This plan does not enumerate specific DevTools MCP commands/APIs; the agent should use whatever capabilities are available via `io.github.chromedevtools/chrome-devtools-mcp/*` in the current environment.
+
+Update to incorporate skills:
+
+- The Web Designer agent should explicitly mention and use the skills:
+  - `website-visual-assets` (for HTML exports + screenshots + inventory updates)
+  - `website-devtools` (for Chrome DevTools MCP usage)
+  - `website-quality-check` (for local verification and repeatable quality checks)
+
+#### Canonical commands to embed into agent guidance
+
+HTML export (GitHub):
+```bash
+dotnet run --project tools/Oocx.TfPlan2Md.HtmlRenderer -- \
+  --input artifacts/comprehensive-demo.md \
+  --flavor github
+# Output: artifacts/comprehensive-demo.github.html
+```
+
+HTML export (Azure DevOps wrapper):
+```bash
+dotnet run --project tools/Oocx.TfPlan2Md.HtmlRenderer -- \
+  --input artifacts/comprehensive-demo.md \
+  --flavor azdo \
+  --template tools/Oocx.TfPlan2Md.HtmlRenderer/templates/azdo-wrapper.html \
+  --output artifacts/comprehensive-demo.azdo.html
+```
+
+Screenshot generation examples:
+
+- Full page:
+```bash
+dotnet run --project tools/Oocx.TfPlan2Md.ScreenshotGenerator -- \
+  --input artifacts/comprehensive-demo.azdo.html \
+  --output website/assets/screenshots/full-report-azdo.png \
+  --full-page
+```
+
+- Target specific Terraform resource:
+```bash
+dotnet run --project tools/Oocx.TfPlan2Md.ScreenshotGenerator -- \
+  --input artifacts/comprehensive-demo.azdo.html \
+  --output website/assets/screenshots/firewall-resource-azdo.png \
+  --target-terraform-resource-id "azurerm_firewall.example"
+```
+
+- Target selector:
+```bash
+dotnet run --project tools/Oocx.TfPlan2Md.ScreenshotGenerator -- \
+  --input artifacts/comprehensive-demo.azdo.html \
+  --output website/assets/screenshots/firewall-details-azdo.png \
+  --target-selector "details:has(summary:has-text('azurerm_firewall'))"
+```
+
+## Implementation steps (what will change)
+
+1. Add website memory directory and files
+   - Create `website/_memory/`.
+  - Add `website/_memory/feature-definitions.md` by copying the table from the 025 doc and adding the required `Icon/Image` column.
+    - Ensure every feature has an assigned icon/image.
+    - Ensure icon/image assignments are unique across features.
+  - Add `website/_memory/site-structure.md` with the initial site map and initial page specs.
+  - Add `website/_memory/screenshots.md` with an initial empty inventory + template entries.
+  - Add `website/_memory/style-guide.md` with initial style rules + decision log scaffold.
+  - Add `website/_memory/non-functional-requirements.md` with the initial NFR list.
+  - Add `website/_memory/code-examples.md` with an initial empty inventory + template entries.
+
+2. Seed the initial site structure doc
+   - Derive the initial site map from the pages that exist in `website/` at the time of implementation.
+     - Current known pages (today): `/website/features/index.html` and `/website/style.css`.
+   - Capture planned/future pages separately (clearly marked as planned), to avoid implying they already exist.
+
+3. Update the Web Designer agent instructions
+   - Add the new memory docs to “Context to Read”.
+   - Add explicit “must update memory docs when decisions change” rules.
+   - Add a “Visual assets workflow” section requiring HTML renderer + screenshot generator usage.
+  - Add a “DevTools workflow” section describing how/when to use Chrome DevTools MCP tools while developing and troubleshooting.
+
+4. Add new skills
+  - Create `.github/skills/website-visual-assets/`.
+  - Create `.github/skills/website-devtools/`.
+  - Create `.github/skills/website-quality-check/`.
+  - Reference these skills from the Web Designer agent instructions.
+
+5. Add/adjust website asset directories as needed
+   - Create `website/assets/screenshots/` (empty at first).
+
+6. (Optional follow-up) Add a website assets directory for code examples (only if needed)
+  - Prefer embedding code blocks directly in HTML pages.
+  - If the site needs separate downloadable example files, add `website/assets/examples/` and track them via `website/_memory/code-examples.md`.
+
+7. (Optional follow-up) Validate agent/tooling instructions
+   - Ensure the documented commands match `README.md` and `docs/features.md`.
+   - Ensure paths are relative to repo root and reproducible.
+
+## Out of scope (for this change)
+
+- Creating new website pages beyond what’s required to host the memory docs.
+- Adding new features, filters, carousels, or new UX beyond the existing spec.
+- Changing the Web Designer agent’s model assignment (unless separately requested).
+
+## Acceptance criteria
+
+- There is a clear “memory” directory under `website/` containing:
+  - Feature representation table (copied from 025).
+  - Site structure + per-page decision log document.
+  - Screenshot inventory document with required fields.
+- Style guide document with design decisions.
+- Non-functional requirements document.
+- Code examples inventory document with generation instructions.
+- Web Designer agent explicitly reads these docs and updates them when decisions change.
+- Screenshot inventory requires exact, reproducible commands using the existing HTML renderer + screenshot generator tools.
+- Web Designer agent is configured to use `io.github.chromedevtools/chrome-devtools-mcp/*` and uses it during website work for inspection/troubleshooting.

--- a/website/_memory/backlog.md
+++ b/website/_memory/backlog.md
@@ -1,0 +1,15 @@
+# Website backlog
+
+This file is the source of truth for all open website tasks.
+
+## Rules
+- Add new work here before starting implementation.
+- Keep each task small and unambiguous.
+- Update **Status** as work progresses.
+- Close tasks by marking them **✅ Done** (do not delete rows).
+
+## Open tasks
+
+| ID | Title | Page(s) | Status | Notes |
+|---:|---|---|---|---|
+| 1 | Fix duplicate feature icons | `/features/` | ⬜ Not started | Uniqueness rule is currently violated (duplicate 🏷️). |

--- a/website/_memory/code-examples.md
+++ b/website/_memory/code-examples.md
@@ -1,0 +1,14 @@
+# Website Code Examples Inventory
+
+This document lists the code examples shown on the website and how to (re)generate them.
+
+## Rules
+
+- Every code example/snippet referenced by the website must have an entry here.
+- Prefer sourcing examples from existing documentation (README.md, docs/) unless explicitly instructed otherwise.
+
+## Inventory
+
+| ID | Used on page | Source-of-truth | How to (re)generate | Purpose |
+|----|--------------|-----------------|---------------------|---------|
+| (add) | (add) | (add) | (add) | (add) |

--- a/website/_memory/feature-definitions.md
+++ b/website/_memory/feature-definitions.md
@@ -1,0 +1,49 @@
+# Feature Definitions (Website)
+
+This document is the **source of truth** for how each tfplan2md feature is represented on the website.
+
+## Rules
+
+- The feature list and categorization (Group/Value) must stay consistent with the agreed feature definitions.
+- The `Icon/Image` assignment must be **unique per feature** (different features may not use the same icon/image).
+- If a feature is reclassified or its icon/image changes, update this file in the same PR.
+
+## Current icon usage status
+
+The website currently uses inline emoji icons on the Features page. This table reflects the **current** icon usage.
+
+Known issue:
+
+- The icon `🏷️` is currently used for multiple features on the website. This violates the uniqueness rule.
+	- We are documenting the current state as-is.
+	- The Web Designer agent will fix this later.
+
+## Feature Table
+
+| Feature | Description | Group | Value | Icon/Image |
+|---------|-------------|-------|-------|-----------|
+| Semantic Diffs | Shows "Before" and "After" values side-by-side for changed attributes, highlighting exactly what changed. | What Sets Us Apart | High | 🔍 |
+| Firewall Rule Interpretation | Renders complex Azure Firewall rule collections as readable tables with protocols, ports, and actions. | What Sets Us Apart | High | assets/icons/firewall-rule-interpretation.svg |
+| NSG Rule Interpretation | Renders Network Security Group rules as readable tables, making security changes easy to audit. | What Sets Us Apart | High | assets/icons/nsg-rule-interpretation.svg |
+| Role Assignment Mapping | Resolves cryptic Principal IDs, Scopes, and Role Names (GUIDs) to human-readable names (e.g., "Jane Doe", "DevOps Team", "Reader on rg-prod"). | What Sets Us Apart | High | assets/icons/role-assignment-mapping.svg |
+| Large Value Formatting | Handles large text blocks (like JSON policies or scripts) by showing a computed diff instead of the full text. Works with inline diffs for maximum clarity. | What Sets Us Apart | High | assets/icons/large-value-formatting.svg |
+| CI/CD Integration | Native support and examples for GitHub Actions, Azure DevOps, and GitLab CI. | What Sets Us Apart | High | assets/icons/cicd-integration.svg |
+| PR Platform Compatibility | Designed and tested for rendering in markdown pull requests on Azure DevOps Services and GitHub. | What Sets Us Apart | High | assets/icons/pr-platform-compatibility.svg |
+| Firewall Rule Interpretation | Renders complex Azure Firewall rule collections as readable tables with protocols, ports, and actions. | What Sets Us Apart | High | 🔥 |
+| NSG Rule Interpretation | Renders Network Security Group rules as readable tables, making security changes easy to audit. | What Sets Us Apart | High | 🛡️ |
+| Role Assignment Mapping | Resolves cryptic Principal IDs, Scopes, and Role Names (GUIDs) to human-readable names (e.g., "Jane Doe", "DevOps Team", "Reader on rg-prod"). | What Sets Us Apart | High | 👥 |
+| Large Value Formatting | Handles large text blocks (like JSON policies or scripts) by showing a computed diff instead of the full text. Works with inline diffs for maximum clarity. | What Sets Us Apart | High | 📄 |
+| CI/CD Integration | Native support and examples for GitHub Actions, Azure DevOps, and GitLab CI. | What Sets Us Apart | High | 🔄 |
+| PR Platform Compatibility | Designed and tested for rendering in markdown pull requests on Azure DevOps Services and GitHub. | What Sets Us Apart | High | 📋 |
+| Friendly Resource Names | Displays friendly names for resources instead of complex resource ID strings. | What Sets Us Apart | High | 🏷️ |
+| Plan Summary | High-level overview table showing counts of adds, changes, and destroys by resource type. | Built-In Capabilities | Medium | 📊 |
+| Module Grouping | Groups resources logically by their Terraform module hierarchy (e.g., module.network). | Built-In Capabilities | Medium | 📁 |
+| Collapsible Details | Hides verbose resource details inside `<details>` tags to keep the PR comment readable. | Built-In Capabilities | Medium | 📂 |
+| Tag Visualization | Renders resource tags with specific icons and formatting for easy scanning. | Built-In Capabilities | Medium | 🏷️ |
+| Smart Iconography | Adds context-aware icons for common attributes like Locations (🌍), IPs (🌐), and Ports (🔌). | Built-In Capabilities | Medium | 🎨 |
+| Custom Templates | Allows users to completely customize the markdown output using Go templates. | Built-In Capabilities | Medium | 🛠️ |
+| Provider Agnostic Core | Works with any Terraform provider (AWS, GCP, etc.) using standard resource rendering. | Built-In Capabilities | Medium | 🌐 |
+| Local Resource Names | In modules, renders the local name part instead of the full name that includes the module path. | Built-In Capabilities | Medium | 📝 |
+| Docker Support | Distributed as a lightweight Docker container for easy usage in any environment. | Also Included | Low | 🐳 |
+| Sensitive Value Masking | Automatically detects and masks sensitive values (marked as sensitive in Terraform) to prevent leaks. | Also Included | Low | 🔒 |
+| Minimal Container Image | Uses mcr.microsoft.com/dotnet/runtime:10.0-noble-chiseled as base for minimal attack surface. | Also Included | Low | 📦 |

--- a/website/_memory/non-functional-requirements.md
+++ b/website/_memory/non-functional-requirements.md
@@ -1,0 +1,31 @@
+# Website Non-Functional Requirements (NFRs)
+
+This document is the **source of truth** for website quality constraints.
+
+## Accessibility
+
+- The website must be fully accessible.
+- Target: WCAG 2.1 AA.
+- Requirements include (non-exhaustive):
+  - Semantic HTML
+  - Proper heading hierarchy
+  - Keyboard navigation
+  - Accessible names for controls
+  - Sufficient contrast
+  - Alt text for meaningful images
+
+## Browser support
+
+- Support only the **latest** version of:
+  - Microsoft Edge
+  - Mozilla Firefox
+
+## Modern web standards
+
+- Usage of modern standards and features (HTML, CSS, JavaScript) is encouraged, as long as they are supported by the supported browsers.
+
+## Performance and maintainability
+
+- Keep dependencies minimal.
+- Prefer static assets and simple HTML/CSS/JS.
+- Keep pages fast to load and easy to modify.

--- a/website/_memory/screenshots.md
+++ b/website/_memory/screenshots.md
@@ -1,0 +1,15 @@
+# Website Screenshot Inventory
+
+This document lists the screenshots used on the website and how to generate them.
+
+## Rules
+
+- Every screenshot referenced by the website must have an entry here.
+- Screenshots must be generated using the HTML renderer + screenshot generator tools.
+- Screenshots should be stored under `website/assets/screenshots/`.
+
+## Inventory
+
+| File | How to generate (exact commands) | Purpose |
+|------|----------------------------------|---------|
+| (add) | (add) | (add) |

--- a/website/_memory/site-structure.md
+++ b/website/_memory/site-structure.md
@@ -1,0 +1,46 @@
+# Website Structure (Source of Truth)
+
+This document is the **source of truth** for the current website structure and for per-page intent.
+
+## Current site map (derived from `website/`)
+
+- `/features/index.html`
+
+## Planned additions (not yet present in `website/`)
+
+- `/index.html`
+- `/getting-started.html`
+- `/docs.html`
+- `/examples.html`
+- `/providers/index.html`
+- `/architecture.html`
+- `/contributing.html`
+
+## Page specifications
+
+### /features/index.html
+
+- **Title:** Features - tfplan2md
+- **Purpose:** Present the feature overview and link to deeper feature pages.
+- **Content summary:** Feature categories (“What Sets Us Apart”, “Built-In Capabilities”, “Also Included”) with brief descriptions and links.
+- **Target audience:** Evaluators, Users
+- **Links to:**
+  - `../index.html` (planned)
+  - `../getting-started.html` (planned)
+  - `../docs.html` (planned)
+  - `../examples.html` (planned)
+  - `../providers/index.html` (planned)
+  - `../architecture.html` (planned)
+  - `../contributing.html` (planned)
+  - `https://github.com/oocx/tfplan2md`
+  - `firewall-rules.html` (planned)
+  - `nsg-rules.html` (planned)
+  - `azure-optimizations.html#principal-mapping` (planned)
+  - `large-values.html` (planned)
+  - `misc.html#friendly-names` (planned)
+  - `misc.html#plan-summary` (planned)
+  - `module-grouping.html` (planned)
+  - `misc.html#collapsible-details` (planned)
+  - `semantic-icons.html#tags` (planned)
+- **Decision log:**
+  - 2026-01-03: Seeded from currently present HTML pages in `website/`.

--- a/website/_memory/style-guide.md
+++ b/website/_memory/style-guide.md
@@ -1,0 +1,39 @@
+# Website Style Guide
+
+This document captures **design and style decisions** for the tfplan2md website.
+
+## Principles
+
+- Keep the site technical and example-driven (no marketing fluff).
+- Prefer simple, maintainable HTML/CSS.
+- Use consistent spacing, typography, and component patterns across pages.
+
+## Theme and tokens
+
+- Theme support: Light and Dark modes.
+- CSS variables are defined in `website/style.css` under `:root[data-theme="light"]` and `:root[data-theme="dark"]`.
+- Keep new styling consistent with existing variables instead of introducing one-off values.
+
+## Layout
+
+- Primary content max width: 1280px (see `.nav-container`, `.hero-container` patterns).
+- Use the existing container + section patterns (`.section`, `.section-container`, `.section-header`) for consistency.
+
+## Typography
+
+- Use the existing heading hierarchy in HTML (`h1` → `h2` → `h3`) and keep it consistent.
+- Prefer the site’s configured system font stack (`--font-sans`) and mono stack (`--font-mono`).
+
+## Navigation
+
+- Keep the nav consistent across pages.
+- Ensure keyboard accessibility (focus order, aria labels on controls).
+
+## Icons and images
+
+- Feature representation must follow `website/_memory/feature-definitions.md`.
+- Do not reuse the same icon/image for different features.
+
+## Decision log
+
+- 2026-01-03: Initial style guide created based on the current `website/style.css` design system.


### PR DESCRIPTION
## Summary
This PR improves the Web Designer workflow by adding website “memory” docs and skills, including a backlog of open website tasks.

## Changes
- Add website memory docs under `website/_memory/` (feature definitions, site structure, style guide, NFRs, screenshots, code examples, backlog)
- Add skills: `website-visual-assets`, `website-devtools`, `website-quality-check`
- Update Web Designer agent to require these memory docs and skills
- Remove Playwright installation instructions from Web Designer-specific guidance (env already set up)

## Validation
- `scripts/validate-agents.py`
