### PR TITLE
refactor: move CI/CD Integration to Built-In Capabilities section

### DIFF
--- a/website/_memory/backlog.md
+++ b/website/_memory/backlog.md
@@ -363,15 +363,15 @@ This file is the source of truth for all open website tasks.
 | Page(s) | `/features/index.html` |
 | Effort | Low |
 | Value | Medium |
-| Status | ⬜ Not started |
+| Status | ✅ Done |
 | Depends On | — |
 
 **Description:** Move CI/CD Integration feature from "What Sets Us Apart" (High priority section) to "Built-In Capabilities" (Medium priority section). Per feature-definitions.md, CI/CD Integration is Medium value.
 
 **Definition of Done:**
-- [ ] CI/CD Integration card removed from "What Sets Us Apart" section
-- [ ] CI/CD Integration card added to "Built-In Capabilities" section
-- [ ] Card content and icon preserved
+- [x] CI/CD Integration card removed from "What Sets Us Apart" section
+- [x] CI/CD Integration card added to "Built-In Capabilities" section
+- [x] Card content and icon preserved
 
 ---
 

--- a/website/features/index.html
+++ b/website/features/index.html
@@ -137,21 +137,6 @@
                     </div>
                 </div>
 
-                <!-- CI/CD Integration -->
-                <div class="feature-category-card featured">
-                    <img src="../assets/icons/cicd-integration.svg" alt="CI/CD Integration" class="feature-icon">
-                    <h3 class="feature-category-title">CI/CD Integration</h3>
-                    <p class="feature-category-description">
-                        Native support and examples for GitHub Actions, Azure DevOps, and GitLab CI. Just pipe terraform output to the Docker container.
-                    </p>
-                    <div class="feature-list">
-                        <a href="../getting-started.html#cicd" class="feature-link">
-                            <span class="feature-link-icon">→</span>
-                            <span>View integration guides</span>
-                        </a>
-                    </div>
-                </div>
-
                 <!-- PR Rendering Optimization -->
                 <div class="feature-category-card featured">
                     <img src="../assets/icons/pr-compatibility.svg" alt="PR Rendering Optimization" class="feature-icon">
@@ -279,6 +264,21 @@
                         <a href="custom-templates.html" class="feature-link">
                             <span class="feature-link-icon">→</span>
                             <span>Learn more</span>
+                        </a>
+                    </div>
+                </div>
+
+                <!-- CI/CD Integration -->
+                <div class="feature-category-card">
+                    <img src="../assets/icons/cicd-integration.svg" alt="CI/CD Integration" class="feature-icon">
+                    <h3 class="feature-category-title">CI/CD Integration</h3>
+                    <p class="feature-category-description">
+                        Native support and examples for GitHub Actions, Azure DevOps, and GitLab CI. Just pipe terraform output to the Docker container.
+                    </p>
+                    <div class="feature-list">
+                        <a href="../getting-started.html#cicd" class="feature-link">
+                            <span class="feature-link-icon">→</span>
+                            <span>View integration guides</span>
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Problem
CI/CD Integration was listed in "What Sets Us Apart" (high priority) section, but according to `feature-definitions.md`, it has Medium value and should be in the "Built-In Capabilities" section instead.

## Change
- Moved CI/CD Integration feature card from "What Sets Us Apart" to "Built-In Capabilities" section
- Preserved card content and icon
- Updated backlog to mark task #16 as done

## Verification
- [x] CI/CD Integration now appears in "Built-In Capabilities" section
- [x] Card content and styling preserved (only changed `featured` class to standard)
- [x] "What Sets Us Apart" now has 7 cards (down from 8)
- [x] "Built-In Capabilities" now has 9 cards (up from 8)
- [x] All links and icons work correctly
