### PR TITLE
fix: restore version to 1.0.0-alpha.18

### DIFF
--- a/src/Oocx.TfPlan2Md/Oocx.TfPlan2Md.csproj
+++ b/src/Oocx.TfPlan2Md/Oocx.TfPlan2Md.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>13</LangVersion>
     <RootNamespace>Oocx.TfPlan2Md</RootNamespace>
-    <Version>1.0.0-alpha.17</Version>
+    <Version>1.0.0-alpha.18</Version>
     <AssemblyName>tfplan2md</AssemblyName>
   </PropertyGroup>
 


### PR DESCRIPTION
Restores the version in Directory.Build.props (via csproj) to 1.0.0-alpha.18 after an accidental revert in an older commit. This unblocks Versionize in CI.
