### PR TITLE
fix(workflow): enforce VS Code preview + DevTools for Web Designer

### DIFF
--- a/.github/agents/web-designer.agent.md
+++ b/.github/agents/web-designer.agent.md
@@ -68,6 +68,8 @@ Determine your environment at the start of each interaction:
 ### ✅ Always Do (VS Code Only)
 - **CRITICAL**: If the user asks a question, answer the question. Do NOT continue with implementation work unless explicitly asked.
 - **CRITICAL**: Wait for explicit user approval before transitioning between phases (design → implementation)
+- **CRITICAL**: For local preview, NEVER start your own web server (Python/Node/etc). Always use VS Code’s built-in preview server at `http://127.0.0.1:3000/website/` (live reload).
+- **CRITICAL**: Use Chrome DevTools MCP tools (`io.github.chromedevtools/chrome-devtools-mcp/*`) to analyze rendering issues and validate that website changes work as expected.
 - Post exact PR Title + Description in chat before creating PR
 - Ask Maintainer for clarification if requirements are unclear
 
@@ -104,6 +106,7 @@ Determine your environment at the start of each interaction:
 - **Continue with implementation when the user asked a question** - answer the question and wait
 - **Start implementation during a design/requirements discussion** - wait for explicit "start implementation" instruction
 - **Ignore the user's actual request** - always parse and respond to exactly what they asked
+- Start a local preview web server (e.g., `python -m http.server`, `npm` dev servers). Use VS Code’s built-in preview server at `http://127.0.0.1:3000/website/`.
 
 ## Response Style
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -391,7 +391,7 @@ For detailed analysis of cloud agents, see [docs/workflow/031-cloud-agents-analy
 ### 13. Web Designer (Specialized Agent)
 - **Goal:** Design, develop, and maintain the tfplan2md website hosted on GitHub Pages.
 - **Execution Modes:**
-  - **Local (VS Code):** Interactive design iterations, prototyping, screenshot generation, Chrome DevTools inspection
+	- **Local (VS Code):** Use VS Code’s built-in preview server (`http://127.0.0.1:3000/website/`) and validate rendering via Chrome DevTools MCP
   - **Cloud (GitHub):** Automated content/style updates via issue assignment for well-defined changes
 - **Deliverables:** Website pages (HTML/CSS), design prototypes, website content derived from existing documentation.
 - **Initial Creation:** Handoff from Architect after technical approach is defined.

--- a/docs/workflow/034-web-designer-local-dev/tasks.md
+++ b/docs/workflow/034-web-designer-local-dev/tasks.md
@@ -1,0 +1,14 @@
+## Candidate workflow improvements
+
+| ID | Title | Source | Status | Rationale | Impact | Effort | Risk | Notes |
+|---:|---|---|---|---|---|---|---|---|
+| 1 | Web Designer: enforce VS Code preview + DevTools | prior-work | ✅ Done | Prevent redundant local servers and standardize rendering validation. | High | Low | Low | Use VS Code built-in server at `http://127.0.0.1:3000/website/` and require Chrome DevTools MCP for validation. |
+
+## Recommendations
+
+- **Option 1 (Best balance of effort/impact):** **1** — Small instruction update prevents recurring workflow friction.
+- **Option 2 (Quick win):** **1** — Single-agent change, immediate value.
+- **Option 3 (Highest impact):** **1** — Standardizes website validation.
+
+## Decision
+Selected: **Task 1** (Maintainer request in VS Code chat, 2026-01-10).


### PR DESCRIPTION
## Problem
The Web Designer agent sometimes starts an ad-hoc local web server (e.g., Python) even though VS Code already provides a local preview server with live reload.

## Change
- Updated the Web Designer agent instructions to never start its own local web server and to always use the VS Code built-in preview URL (`http://127.0.0.1:3000/website/`).
- Required using Chrome DevTools MCP tools for analyzing rendering issues and validating website changes in local development.
- Updated workflow documentation and added a workflow `tasks.md` entry for traceability.

## Verification
- Ran `scripts/validate-agents.py`.
