### PR TITLE
feat(workflow): add website verify wrapper

### DIFF
--- a/.github/agents/web-designer.agent.md
+++ b/.github/agents/web-designer.agent.md
@@ -123,6 +123,44 @@ Todo lists:
 - Keep the todo list updated as steps move from not-started → in-progress → completed.
 - Skip todo lists for simple Q&A or one-step actions.
 
+## Definition of Done (CRITICAL)
+
+You must NOT claim a website task is “done” (and must NOT hand off for PR) until **all** items below are satisfied. If you cannot satisfy an item, say so explicitly, explain why, and propose the smallest next action that will unblock it.
+
+### Required evidence (VS Code / Local)
+- **Files changed:** Run `scripts/git-status.sh --porcelain=v1` and summarize the changed files under `website/`.
+- **Build/Problems panel:** Check `read/problems` and confirm no new errors were introduced by your edits.
+- **Verify (mandatory):** Run `scripts/website-verify.sh` (includes `scripts/website-lint.sh`) and fix any errors before claiming “done”.
+- **Preview render:** Open the changed pages via VS Code preview at `http://127.0.0.1:3000/website/` and confirm they render (no missing CSS/JS).
+- **DevTools sanity:** Use Chrome DevTools MCP (`io.github.chromedevtools/chrome-devtools-mcp/*`) to confirm:
+   - No console errors on the changed pages
+   - Layout is reasonable at least at mobile and desktop widths
+- **Style guide compliance (mandatory):** Validate the change against `website/_memory/style-guide.md`.
+   - If your change modifies a “shared” design decision (spacing, typography, containers, component patterns), update the style guide in the same PR.
+   - If you update the style guide, you must also update every affected page/component so the site is consistent.
+   - If you introduce a new reusable design element (new component class/pattern likely to be used elsewhere), document it in the style guide with selector name + intended usage.
+- **Style guide accuracy check (mandatory):** If the style guide contains specific numeric values (e.g., section padding), verify they still match `website/style.css`. If not, update the style guide.
+- **Shared component propagation (mandatory):** If you change a shared component (CSS class, JS behavior, or HTML pattern used across pages), you must:
+   - Use `search` to find all usages across `website/`
+   - Update all affected pages/files in the same change
+   - Explicitly list which pages/files were updated in your “Done” response
+- **NFR checklist:** For each changed page, verify essentials from `website/_memory/non-functional-requirements.md` (use `website-quality-check` as the baseline).
+
+### Required evidence (Cloud)
+- **Files changed:** List all files changed under `website/`.
+- **Verify (mandatory):** If the repo includes `scripts/website-verify.sh`, run it on your branch and fix failures before creating a PR.
+- **Static reasoning checks:** Confirm semantic HTML, accessibility basics (headings, labels/alt text), and that relative links/asset paths are correct.
+- **Limitations stated:** If you can’t preview/run DevTools in cloud mode, state that clearly and mark it as a follow-up for local verification.
+
+### Required “Done” response format
+When you claim completion, include these sections (short and factual):
+- **What changed:** 1–3 bullets.
+- **Files:** bulleted list of changed `website/` files.
+- **Verification:** bullets with evidence (commands run + outcomes; lint results; DevTools check results; Problems panel status).
+- **Style guide:** state whether `website/_memory/style-guide.md` changed; if yes, state which site-wide updates were made to match it; if no, state that the change was validated against it.
+- **Shared components:** if any shared pattern/component was modified, state how you verified all usages were updated.
+- **Known limitations / follow-ups:** only if applicable.
+
 **Next**
 - **Option 1:** <clear next action>
 - **Option 2:** <clear alternative>

--- a/.github/skills/website-quality-check/SKILL.md
+++ b/.github/skills/website-quality-check/SKILL.md
@@ -12,6 +12,8 @@ Provide a lightweight, repeatable quality checklist for website changes.
 ### Must
 - [ ] Verify the change follows `website/_memory/style-guide.md`.
 - [ ] Verify the change follows `website/_memory/non-functional-requirements.md`.
+- [ ] If any HTML/CSS/JS files changed under `website/`, run `scripts/website-verify.sh` and fix failures.
+- [ ] If local preview is available, open the changed pages and ensure the browser console has no errors.
 - [ ] Do quick link/navigation sanity checks on changed pages.
 - [ ] Do basic accessibility spot checks (headings, aria labels, keyboard navigation where relevant).
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -397,7 +397,7 @@ For detailed analysis of cloud agents, see [docs/workflow/031-cloud-agents-analy
 - **Deliverables:** Website pages (HTML/CSS), design prototypes, website content derived from existing documentation.
 - **Initial Creation:** Handoff from Architect after technical approach is defined.
 - **Ongoing Changes:** Direct handoff from Maintainer for content, design, or functionality updates (local), or via GitHub issue assignment (cloud).
-- **Definition of Done:** Website changes are complete, accessible (WCAG 2.1 AA), responsive, and PR is created.
+- **Definition of Done:** Website changes are complete, accessible (WCAG 2.1 AA), responsive, and the agent provides verification evidence (changed files, Problems panel clean, VS Code preview render, DevTools console clean, style/NFR checklist). Changes must be validated against the style guide; style guide updates require site-wide consistency updates, and new reusable design elements must be documented.
 - **Cloud Limitations:** Cannot generate screenshots, preview locally, or use Chrome DevTools. Best for content/text updates and style changes that don't require visual verification.
 - **Note:** This agent operates independently for website-specific work. Website files live in `/website/` directory with isolated CI/CD pipeline triggers.
 

--- a/docs/workflow/035-web-designer-quality/tasks.md
+++ b/docs/workflow/035-web-designer-quality/tasks.md
@@ -1,0 +1,19 @@
+## Candidate workflow improvements
+
+| ID | Title | Source | Status | Rationale | Impact | Effort | Risk | Notes |
+|---:|---|---|---|---|---|---|---|---|
+| 1 | Web Designer: add strict “Definition of Done” (DoD) + evidence | Maintainer feedback (2026-01-11) | ✅ Done | Agent frequently claims completion without working output. A DoD reduces false positives and tightens iteration loops. | High | Low | Low | Implemented in `.github/agents/web-designer.agent.md` and aligned in `docs/agents.md` (includes style guide validation/updates, and shared-component propagation). |
+| 2 | Add `scripts/website-lint.sh` (HTML/CSS/JS) + configs | Maintainer feedback (2026-01-11) | ✅ Done | Linting catches broken/incomplete UI changes early and provides objective failure signals for the agent to fix before claiming done. | High | Med | Med | Added `scripts/website-lint.sh` + `website/.htmlhintrc` + `website/.stylelintrc.json` + `website/eslint.config.js`. Calibrated `--all` to ignore prototype/icon HTML and fixed remaining baseline HTML issues. |
+| 3 | Add `scripts/website-verify.sh` wrapper (lint + basic checks) | prior-work + Maintainer feedback (2026-01-11) | ✅ Done | One command reduces tool-choice ambiguity and makes verification habitual for the agent. | Med | Low | Low | Added `scripts/website-verify.sh` which runs `scripts/website-lint.sh` plus a lightweight static link/asset existence check for HTML. |
+| 4 | Web Designer: switch model away from Claude Sonnet 4.5 | docs/ai-model-reference.md (Instruction Following + Coding) | ⬜ Not started | Claude Sonnet 4.5 scores poorly for Coding and Instruction Following; aligns with observed “incomplete/broken implementation” behavior. | High | Low | Med | Candidates: `GPT-5.1-Codex-Max` (best coding) or `Gemini 3 Flash (Preview)` (best instruction following/cost). |
+| 5 | Web Designer: require Chrome DevTools console “clean” check before done | prior-work (#034) + Maintainer feedback (2026-01-11) | ✅ Done | Many web bugs show up as console errors or missing assets; DevTools provides fast validation signal. | Med | Low | Low | Added to Web Designer DoD: must check DevTools and report “no console errors” (or list and fix). |
+| 6 | Extend `website-quality-check` skill to include lint + console checks | Maintainer feedback (2026-01-11) | ✅ Done | Consolidates quality gates in a reusable checklist, reducing drift across agent updates. | Med | Low | Low | Skill now mandates `scripts/website-lint.sh` for any website HTML/CSS/JS changes and includes a DevTools console sanity check when available. |
+
+## Recommendations
+
+- **Option 1 (Best balance of effort/impact):** **1** — Tightens “done” definition immediately with minimal repo/tooling changes.
+- **Option 2 (Quick win):** **5** — Low-effort guardrail that catches many breakages early.
+- **Option 3 (Highest impact):** **2** — Introduces objective quality gates (linters) that directly address incomplete/broken outputs.
+
+## Decision
+Which item should I implement first? (Reply with the Option number, or reply with "work on task <task id>")

--- a/scripts/website-lint.sh
+++ b/scripts/website-lint.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/website-lint.sh [--all] [--base <ref>]
+
+Lints website files (HTML/CSS/JS) using on-demand tools via npx.
+
+Default behavior:
+  - Lints only files changed vs <base> (auto-detected, default origin/main)
+
+Options:
+  --all           Lint all website files (can be slower / noisier)
+  --base <ref>    Git ref to diff against (default: origin/main if present)
+EOF
+}
+
+lint_all=false
+base_ref=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      lint_all=true
+      shift
+      ;;
+    --base)
+      base_ref="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: node is required for website linting." >&2
+  echo "Install Node.js, then re-run: scripts/website-lint.sh" >&2
+  exit 1
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "Error: npx is required for website linting." >&2
+  echo "Install npm (Node.js), then re-run: scripts/website-lint.sh" >&2
+  exit 1
+fi
+
+if [[ -z "$base_ref" ]]; then
+  if git show-ref --verify --quiet refs/remotes/origin/main; then
+    base_ref="origin/main"
+  else
+    base_ref="HEAD~1"
+  fi
+fi
+
+collect_changed_files() {
+  local pattern="$1"
+  git diff --name-only --diff-filter=ACMR "${base_ref}...HEAD" -- website \
+    | grep -E "$pattern" || true
+}
+
+html_files=()
+css_files=()
+js_files=()
+
+if [[ "$lint_all" == "true" ]]; then
+  while IFS= read -r file; do html_files+=("$file"); done < <(
+    find website \
+      -type f -name '*.html' \
+      ! -path 'website/prototypes/*' \
+      ! -path 'website/assets/icons/*.html' \
+      -print
+  )
+  while IFS= read -r file; do css_files+=("$file"); done < <(find website -type f -name '*.css' -print)
+  while IFS= read -r file; do js_files+=("$file"); done < <(find website -type f -name '*.js' -print)
+else
+  while IFS= read -r file; do html_files+=("$file"); done < <(collect_changed_files '\\.html$')
+  while IFS= read -r file; do css_files+=("$file"); done < <(collect_changed_files '\\.css$')
+  while IFS= read -r file; do js_files+=("$file"); done < <(collect_changed_files '\\.js$')
+fi
+
+if [[ ${#html_files[@]} -eq 0 && ${#css_files[@]} -eq 0 && ${#js_files[@]} -eq 0 ]]; then
+  echo "No changed website HTML/CSS/JS files detected. Nothing to lint."
+  exit 0
+fi
+
+echo "Website lint base: ${base_ref}"
+
+if [[ ${#html_files[@]} -gt 0 ]]; then
+  echo "Linting HTML (${#html_files[@]} file(s))..."
+  npx --yes htmlhint@1.1.4 --config website/.htmlhintrc "${html_files[@]}"
+fi
+
+if [[ ${#css_files[@]} -gt 0 ]]; then
+  echo "Linting CSS (${#css_files[@]} file(s))..."
+  npx --yes stylelint@16.10.0 --config website/.stylelintrc.json "${css_files[@]}"
+fi
+
+if [[ ${#js_files[@]} -gt 0 ]]; then
+  echo "Linting JS (${#js_files[@]} file(s))..."
+  # Only lint our website JS (avoid noise in third-party/vendor JS if any gets added later)
+  filtered_js_files=()
+  for file in "${js_files[@]}"; do
+    if [[ "$file" == website/assets/js/* ]]; then
+      filtered_js_files+=("$file")
+    fi
+  done
+
+  if [[ ${#filtered_js_files[@]} -gt 0 ]]; then
+    npx --yes eslint@9.20.0 --config website/eslint.config.js "${filtered_js_files[@]}"
+  else
+    echo "Skipping JS lint: no changed files under website/assets/js/."
+  fi
+fi
+
+echo "Website lint OK."

--- a/scripts/website-verify.sh
+++ b/scripts/website-verify.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/website-verify.sh [--all] [--base <ref>]
+
+Runs a lightweight verification suite for website changes:
+  1) Lint website HTML/CSS/JS via scripts/website-lint.sh
+  2) Basic static checks for broken local links and asset references in HTML
+
+Options:
+  --all           Verify all website files (can be slower)
+  --base <ref>    Git ref to diff against (default: origin/main if present)
+EOF
+}
+
+lint_all=false
+base_ref=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      lint_all=true
+      shift
+      ;;
+    --base)
+      base_ref="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ ! -x scripts/website-lint.sh ]]; then
+  echo "Error: scripts/website-lint.sh not found or not executable." >&2
+  exit 1
+fi
+
+# 1) Lint first (hard gate)
+args=()
+if [[ "$lint_all" == "true" ]]; then
+  args+=("--all")
+fi
+if [[ -n "$base_ref" ]]; then
+  args+=("--base" "$base_ref")
+fi
+
+scripts/website-lint.sh "${args[@]}"
+
+# 2) Static link/asset existence checks (HTML only)
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Warning: python3 not found; skipping link/asset verification." >&2
+  echo "Website verify OK (lint-only)."
+  exit 0
+fi
+
+if [[ -z "$base_ref" ]]; then
+  if git show-ref --verify --quiet refs/remotes/origin/main; then
+    base_ref="origin/main"
+  else
+    base_ref="HEAD~1"
+  fi
+fi
+
+html_files=()
+if [[ "$lint_all" == "true" ]]; then
+  while IFS= read -r file; do html_files+=("$file"); done < <(
+    find website \
+      -type f -name '*.html' \
+      ! -path 'website/prototypes/*' \
+      ! -path 'website/assets/icons/*.html' \
+      -print
+  )
+else
+  while IFS= read -r file; do html_files+=("$file"); done < <(
+    git diff --name-only --diff-filter=ACMR "${base_ref}...HEAD" -- website \
+      | grep -E '\.html$' || true
+  )
+fi
+
+if [[ ${#html_files[@]} -eq 0 ]]; then
+  echo "No website HTML files to verify."
+  echo "Website verify OK."
+  exit 0
+fi
+
+python3 - <<'PY' "${html_files[@]}"
+import os
+import re
+import sys
+
+html_files = sys.argv[1:]
+website_root = os.path.abspath("website")
+
+# Basic attribute extraction. This is intentionally lightweight (not a full HTML parser).
+ATTR_RE = re.compile(r"\b(?:href|src)=([\"'])(.+?)\1", re.IGNORECASE)
+
+IGNORE_PREFIXES = (
+    "http://",
+    "https://",
+    "mailto:",
+    "tel:",
+    "data:",
+    "javascript:",
+    "//",
+)
+
+missing = []
+
+def normalize_ref(value: str) -> str:
+    # Strip fragments and query strings.
+    value = value.split("#", 1)[0]
+    value = value.split("?", 1)[0]
+    return value.strip()
+
+
+def resolve_path(html_path: str, ref: str) -> str | None:
+    ref = normalize_ref(ref)
+    if not ref or ref == "/" or ref.startswith("#"):
+        return None
+    if ref.startswith(IGNORE_PREFIXES):
+        return None
+
+    # Root-relative paths map to website root.
+    if ref.startswith("/"):
+        candidate = os.path.join(website_root, ref.lstrip("/"))
+    else:
+        candidate = os.path.normpath(os.path.join(os.path.dirname(html_path), ref))
+
+    candidate_abs = os.path.abspath(candidate)
+
+    # Require refs to stay within website/.
+    if not candidate_abs.startswith(website_root + os.sep) and candidate_abs != website_root:
+        return None
+
+    return candidate_abs
+
+
+def exists_for_ref(candidate_abs: str, original_ref: str) -> bool:
+    # If ref ends with '/', treat it as a directory link.
+    if original_ref.rstrip().endswith("/"):
+        return os.path.isdir(candidate_abs) and os.path.isfile(os.path.join(candidate_abs, "index.html"))
+
+    return os.path.exists(candidate_abs)
+
+
+for html_file in html_files:
+    html_abs = os.path.abspath(html_file)
+    try:
+        with open(html_abs, "r", encoding="utf-8") as f:
+            content = f.read()
+    except OSError as e:
+        missing.append((html_file, f"(cannot read file: {e})"))
+        continue
+
+    for _, raw in ATTR_RE.findall(content):
+        ref = raw.strip()
+        candidate_abs = resolve_path(html_abs, ref)
+        if candidate_abs is None:
+            continue
+
+        if not exists_for_ref(candidate_abs, ref):
+            # Show paths relative to repo root for readability.
+            rel_candidate = os.path.relpath(candidate_abs, os.path.abspath("."))
+            missing.append((html_file, f"{ref} -> {rel_candidate}"))
+
+if missing:
+    print("Broken local links/assets detected:")
+    for html_file, detail in missing:
+        print(f"- {html_file}: {detail}")
+    sys.exit(1)
+
+print(f"Static link/asset check OK ({len(html_files)} HTML file(s)).")
+PY
+
+echo "Website verify OK."

--- a/website/.htmlhintrc
+++ b/website/.htmlhintrc
@@ -1,0 +1,10 @@
+{
+  "attr-lowercase": true,
+  "attr-value-double-quotes": true,
+  "doctype-first": false,
+  "doctype-html5": true,
+  "id-unique": true,
+  "src-not-empty": true,
+  "alt-require": true,
+  "title-require": true
+}

--- a/website/.stylelintrc.json
+++ b/website/.stylelintrc.json
@@ -1,0 +1,14 @@
+{
+  "rules": {
+    "block-no-empty": true,
+    "color-no-invalid-hex": true,
+    "declaration-block-no-duplicate-properties": [
+      true,
+      {
+        "ignore": [
+          "consecutive-duplicates-with-different-values"
+        ]
+      }
+    ]
+  }
+}

--- a/website/eslint.config.js
+++ b/website/eslint.config.js
@@ -1,0 +1,24 @@
+export default [
+  {
+    files: ["assets/js/**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "script",
+      globals: {
+        window: "readonly",
+        document: "readonly",
+        localStorage: "readonly",
+        console: "readonly",
+        navigator: "readonly",
+        location: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly"
+      }
+    },
+    rules: {
+      "no-undef": "error"
+    }
+  }
+];

--- a/website/examples.html
+++ b/website/examples.html
@@ -80,10 +80,10 @@
                     </div>
                     <div class="example-content">
                         <div class="view-pane rendered-view active">
-<h1 id="user-content-terraform-plan-summary">Terraform Plan Summary</h1>
+<h1>Terraform Plan Summary</h1>
 <p><strong>Terraform Version:</strong> 1.14.0</p>
 <p><strong>Generated:</strong> 2025-12-20T14:30:00Z</p>
-<h2 id="user-content-summary">Summary</h2>
+<h2>Summary</h2>
 <table>
 <thead>
 <tr>
@@ -172,9 +172,9 @@
                     </div>
                     <div class="example-content">
                         <div class="view-pane rendered-view active">
-<h1 id="user-content-terraform-plan-report">Terraform Plan Report</h1>
+<h1>Terraform Plan Report</h1>
 <p><strong>Terraform Version:</strong> 1.14.0</p>
-<h2 id="user-content-summary">Summary</h2>
+<h2>Summary</h2>
 <table>
 <thead>
 <tr>
@@ -201,8 +201,8 @@
 </tr>
 </tbody>
 </table>
-<h2 id="user-content-resource-changes">Resource Changes</h2>
-<h3 id="user-content-%F0%9F%93%A6-module%3A-root">📦 Module: root</h3>
+<h2>Resource Changes</h2>
+<h3>📦 Module: root</h3>
 <details style="margin-bottom:12px; border:1px solid rgb(var(--palette-neutral-10, 153, 153, 153)); padding:12px">
 <summary>➕ azurerm_resource_group <b><code>core</code></b> — <code>🆔 rg-tfplan2md-demo</code> <code>🌍 eastus</code></summary>
 <br/>
@@ -434,8 +434,8 @@
                     </div>
                     <div class="example-content">
                         <div class="view-pane rendered-view active">
-<h2 id="user-content-resource-changes">Resource Changes</h2>
-<h3 id="user-content-%F0%9F%93%A6-module%3A-root">📦 Module: root</h3>
+<h2>Resource Changes</h2>
+<h3>📦 Module: root</h3>
 <details style="margin-bottom:12px; border:1px solid rgb(var(--palette-neutral-10, 153, 153, 153)); padding:12px">
 <summary>➕ azurerm_resource_group <b><code>core</code></b> — <code>🆔 rg-tfplan2md-demo</code> <code>🌍 eastus</code></summary>
 <br/>
@@ -503,7 +503,7 @@
 <p><strong>🏷️ Tags:</strong> <code>cost_center: ops</code> <code>environment: demo</code></p>
 </details>
 <hr/>
-<h3 id="user-content-%F0%9F%93%A6-module%3A-%60module.network%60">📦 Module: <code>module.network</code></h3>
+<h3>📦 Module: <code>module.network</code></h3>
 <details style="margin-bottom:12px; border:1px solid rgb(var(--palette-neutral-10, 153, 153, 153)); padding:12px">
 <summary>➕ azurerm_virtual_network <b><code>hub</code></b> — <code>🆔 vnet-hub</code> in <code>📁 rg-tfplan2md-demo</code> <code>🌍 eastus</code> <code>🌐 10.0.0.0/16</code></summary>
 <br/>
@@ -536,7 +536,7 @@
 <p><strong>🏷️ Tags:</strong> <code>environment: demo</code></p>
 </details>
 <hr/>
-<h3 id="user-content-%F0%9F%93%A6-module%3A-%60module.security%60">📦 Module: <code>module.security</code></h3>
+<h3>📦 Module: <code>module.security</code></h3>
 <details style="margin-bottom:12px; border:1px solid rgb(var(--palette-neutral-10, 153, 153, 153)); padding:12px">
 <summary>➕ azurerm_role_assignment <b><code>rg_reader</code></b> — <code>👤 Jane Doe (User)</code> → <code>🛡️ Reader</code> on <code>rg-tfplan2md-demo</code></summary>
 <br/>
@@ -572,7 +572,7 @@
 </table>
 </details>
 <hr/>
-<h3 id="user-content-%F0%9F%93%A6-module%3A-%60module.network.module.monitoring%60">📦 Module: <code>module.network.module.monitoring</code></h3>
+<h3>📦 Module: <code>module.network.module.monitoring</code></h3>
 <details style="margin-bottom:12px; border:1px solid rgb(var(--palette-neutral-10, 153, 153, 153)); padding:12px">
 <summary>➕ azurerm_log_analytics_workspace <b><code>network</code></b> — <code>🆔 law-network-monitoring</code> in <code>📁 rg-tfplan2md-demo</code> <code>🌍 eastus</code></summary>
 <br/>


### PR DESCRIPTION
## Problem
Website changes were often marked “done” without objective verification, leading to incomplete/broken implementations slipping through. Running multiple manual checks is error-prone and hard to standardize for agents.

## Change
- Add scripts/website-verify.sh: a single wrapper that runs scripts/website-lint.sh plus a lightweight static check for broken local href/src references in HTML.
- Wire the wrapper into the Web Designer Definition of Done and the website-quality-check skill so “verify” is the required pre-done gate.
- Add lint configs under website/ and calibrate full-site lint scope to focus on production pages (exclude prototypes and icon HTML).
- Fix existing duplicate ids in website/examples.html so the HTML id-unique lint rule passes.

## Verification
- Ran scripts/validate-agents.py (OK).
- Ran scripts/website-verify.sh --all (lint + static link/asset checks OK).
