### PR TITLE
fix(workflow): enforce PR coding-agent branch safety

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -50,6 +50,7 @@ If it's not clear, ask the Maintainer for the exact folder path.
 
 ### ✅ Always Do
 - Analyze existing codebase patterns before designing
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**. Commit only to the provided branch so changes appear in the PR.
 - Consider multiple implementation approaches
 - Document trade-offs for each option clearly
 - Present your recommendation with rationale
@@ -272,7 +273,9 @@ Your work is complete when:
    git commit -m "docs: add architecture for <feature-name>"
    ```
 
-3. **Do NOT push** - The changes stay on the local branch until Release Manager creates the PR.
+3. **VS Code (local): Do NOT push** - The changes stay on the local branch until Release Manager creates the PR.
+
+   **GitHub PR coding agent (existing PR):** Updates must land on the provided PR branch so they show up in the PR.
 
 ## Handoff
 

--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -48,6 +48,7 @@ If it's not clear, ask the Maintainer for the exact folder path.
 
 ### ✅ Always Do
 - Check Docker availability before running Docker build (ask maintainer to start if needed)
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**. Commit only to the provided branch so changes appear in the PR.
 - Run `scripts/test-with-timeout.sh -- dotnet test` and `docker build` to verify functionality
 - Generate comprehensive demo output and verify it passes markdownlint (always, not just when feature impacts markdown)
 - Check that all acceptance criteria are met

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -40,6 +40,7 @@ If it's not clear, ask the Maintainer for the exact folder path.
 
 ### ✅ Always Do
 - Sync with latest main before starting ANY work (initial implementation, rework, or fixes)
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**. Commit only to the provided branch so changes appear in the PR.
 - Verify you're on the correct feature branch (created by Requirements Engineer)
 - Check Docker availability before running Docker tests (ask Maintainer to start if needed)
 - Work on ONE task at a time - do not move to next task until current task is complete
@@ -193,6 +194,7 @@ Follow the project's coding conventions strictly:
    scripts/git-status.sh  # Confirm you're on feature/<name> branch
    git fetch origin && git rebase origin/main  # Get latest changes from main
    ```
+   - In GitHub PR coding agent context, you are already on the PR branch (often `copilot/*`) — do not `git switch` to another branch.
    - This prevents merge conflicts later
    - Required for both initial implementation and rework after failed PR/CI validation
 

--- a/.github/agents/issue-analyst.agent.md
+++ b/.github/agents/issue-analyst.agent.md
@@ -54,6 +54,7 @@ If it's not clear, ask the Maintainer for the exact folder path.
 ## Boundaries
 
 ### ✅ Always Do
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**. Commit only to the provided branch so changes appear in the PR.
 - Create new fix branch from latest main BEFORE starting investigation
 - Ask one clarifying question at a time
 - Reproduce the issue if possible
@@ -115,6 +116,8 @@ Before investigating, review relevant context:
 ### Step 0: Create Fix Branch
 
 **ALWAYS do this FIRST, before any investigation:**
+
+**Exception (GitHub PR coding agent):** If you're already working on an existing PR branch (often `copilot/*`), do **not** create/switch branches. Stay on the provided branch and use PR comments as the feedback loop for any clarifications.
 
 ```bash
 # Determine the next available issue number

--- a/.github/agents/quality-engineer.agent.md
+++ b/.github/agents/quality-engineer.agent.md
@@ -40,6 +40,7 @@ If it's not clear, ask the Maintainer for the exact folder path.
 
 ### ✅ Always Do
 - Map every acceptance criterion to at least one test case
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**. Commit only to the provided branch so changes appear in the PR.
 - Ensure all automated tests are fully automated (no manual steps)
 - For user-facing features (CLI changes, rendering changes), define **UAT Test Plans** for Maintainer review via PRs in `docs/features/NNN-<feature-slug>/uat-test-plan.md`
 - Follow xUnit and AwesomeAssertions patterns
@@ -308,7 +309,9 @@ Your work is complete when:
    git commit -m "docs: add test plan for NNN-<feature-slug>"
    ```
 
-2. **Do NOT push** - The changes stay on the local branch until Release Manager creates the PR.
+2. **VS Code (local): Do NOT push** - The changes stay on the local branch until Release Manager creates the PR.
+
+   **GitHub PR coding agent (existing PR):** Updates must land on the provided PR branch so they show up in the PR.
 
 ## Handoff
 

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -44,6 +44,7 @@ If it's not clear, ask the Maintainer for the exact folder path.
 
 ### ✅ Always Do
 - Verify code review is approved before proceeding
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**. Commit only to the provided branch so changes appear in the PR.
 - Trust CI pipeline for test validation — only run local tests (`scripts/test-with-timeout.sh -- dotnet test`) if diagnosing a specific CI failure
 - Verify Docker image builds successfully (only if not recently verified by Code Reviewer)
 - Check that working directory is clean

--- a/.github/agents/requirements-engineer.agent.md
+++ b/.github/agents/requirements-engineer.agent.md
@@ -56,6 +56,7 @@ This includes both:
 
 ### ✅ Always Do
 - Create feature branch from latest main before starting (for NEW features only)
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**. Commit only to the provided branch so changes appear in the PR.
 - Ask one question at a time, wait for answer
 - Focus on WHAT users need, not HOW to implement it
 - Listen completely before asking clarifying questions

--- a/.github/agents/retrospective.agent.md
+++ b/.github/agents/retrospective.agent.md
@@ -38,6 +38,7 @@ If it's not clear, ask the Maintainer for the exact folder path.
 ## Boundaries
 ✅ **Always Do:**
 - Analyze the **full feature lifecycle** from initial request through requirements, design, implementation, testing, UAT, release, and retrospective itself.
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**.
 - Collect **mandatory metrics**: duration, total requests, rejections (cancelled/failed), file edit statistics (kept/undone), files changed, tests added/passed.
 - **Export and save chat history** using `workbench.action.chat.export` command for each agent session (ask Maintainer to focus chat first if needed). Save files with descriptive names like `<agent-name>.chat.json` (e.g., `developer.chat.json`, `architect.chat.json`).
 - **Redact sensitive information** before committing chat logs: scan for and replace passwords, tokens, API keys, secrets, and personally identifiable information (PII) with `[REDACTED]`.

--- a/.github/agents/task-planner.agent.md
+++ b/.github/agents/task-planner.agent.md
@@ -64,6 +64,7 @@ If it's not clear, ask the Maintainer for the exact folder path.
 
 ### ✅ Always Do
 - Break features into small, independently testable tasks
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**. Commit only to the provided branch so changes appear in the PR.
 - Write clear, measurable acceptance criteria for each task
 - Prioritize tasks based on dependencies and risk
 - Ensure each task maps back to the Feature Specification
@@ -237,7 +238,9 @@ Your work is complete when:
    git commit -m "docs: add tasks for <feature-name>"
    ```
 
-2. **Do NOT push** - The changes stay on the local branch until Release Manager creates the PR.
+2. **VS Code (local): Do NOT push** - The changes stay on the local branch until Release Manager creates the PR.
+
+   **GitHub PR coding agent (existing PR):** Updates must land on the provided PR branch so they show up in the PR.
 
 3. **Do NOT start implementing** - Your role ends here. Use the handoff button.
 

--- a/.github/agents/technical-writer.agent.md
+++ b/.github/agents/technical-writer.agent.md
@@ -40,6 +40,7 @@ If it's not clear, ask the Maintainer for the exact folder path.
 
 ### ✅ Always Do
 - Review implementation to understand actual behavior
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**. Commit only to the provided branch so changes appear in the PR.
 - Update README.md for user-facing changes
 - Update docs/features.md with new feature descriptions
 - Ensure consistency across all documentation files

--- a/.github/agents/uat-tester.agent.md
+++ b/.github/agents/uat-tester.agent.md
@@ -44,6 +44,7 @@ If it's not clear, ask the Maintainer for the exact folder path.
 
 ### ✅ Always Do
 - Check for test plans in `docs/features/*/uat-test-plan.md` or `docs/test-plans/*.md` and use validation steps if they exist
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**.
 - **Validate artifact before running**: Verify the specified artifact exercises the changed code paths. If using a default artifact (e.g., comprehensive-demo.md), confirm it will test the new feature. If not, generate a feature-specific artifact first.
 - Call `scripts/uat-run.sh` directly (NOT `bash scripts/uat-run.sh`) for permanent allow
 - For simulations: Set `UAT_SIMULATE=true` environment variable

--- a/.github/agents/web-designer.agent.md
+++ b/.github/agents/web-designer.agent.md
@@ -26,6 +26,7 @@ This agent supports both local (VS Code) and cloud (GitHub) execution. See the `
 ### ✅ Always Do (Both Contexts)
 - **CRITICAL**: Before making ANY changes, ensure you're on an up-to-date feature branch, NOT main
 - Check current branch: `git branch --show-current` - if on main, STOP and create feature branch first
+- **GitHub PR coding agent safety:** If the current branch starts with `copilot/` (or you're operating in an existing PR created by GitHub Copilot), **do not switch branches** and **do not create a new branch**. Commit only to the provided branch so changes appear in the PR.
 - Use branch naming convention: `website/<description>` (e.g., `website/update-homepage-cta`)
 - Sync with latest main before starting work (use `git-rebase-main` skill if needed)
 - **CRITICAL**: Only make the EXACT changes requested by the user - nothing more, nothing less

--- a/.github/agents/workflow-engineer.agent.md
+++ b/.github/agents/workflow-engineer.agent.md
@@ -15,8 +15,6 @@ Evolve and optimize the agent workflow by creating new agents, modifying existin
 
 ## Execution Context
 
-## Execution Context
-
 This agent supports both local (VS Code) and cloud (GitHub) execution. See the `execution-context-detection` skill for detailed guidance on:
 - How to detect your current environment
 - Behavioral differences between contexts

--- a/.github/agents/workflow-orchestrator.agent.md
+++ b/.github/agents/workflow-orchestrator.agent.md
@@ -37,6 +37,7 @@ Execute complete feature implementations or bug fixes autonomously by **delegati
 2. **You NEVER ask clarifying questions** - If requirements are unclear, immediately delegate to Requirements Engineer to gather them
 3. **Your sole job is to delegate** - Use the `task` tool to invoke specialized agents in the correct sequence
 4. **Trust specialized agents** - Every agent has the tools they need; never assume limitations or do their work
+5. **PR coding agent safety:** If you are running on an existing PR branch (often `copilot/*`), do not instruct agents to create/switch branches; all work must land on the provided branch so it appears in the PR.
 
 ## Core Responsibilities
 

--- a/.github/skills/execution-context-detection/SKILL.md
+++ b/.github/skills/execution-context-detection/SKILL.md
@@ -35,7 +35,8 @@ Enable agents to detect their execution environment and adapt behavior appropria
 #### GitHub Pull Request (PR Coding Agent)
 - You are executing as a GitHub Copilot **coding agent on an existing pull request**
 - Work on the **branch already associated with the PR** (often `copilot/*`)
-- **Do not create/switch branches**; otherwise changes may not appear in the PR
+- **Do not switch branches** and **do not create a new branch**; otherwise changes may not appear in the PR
+- Ensure commits are made on the provided PR branch so files appear in the PR
 - If clarification is needed, **ask via PR comments** and wait for an answer (do not guess)
 
 ## Detection Methods

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -335,7 +335,7 @@ The tfplan2md workflow supports both **local agents** (running in VS Code) and *
 - Relies on CI/CD for validation
 
 **Cloud (GitHub PR coding agent):**
-- Works on an existing PR branch (often `copilot/*`) — do not switch branches
+- Works on an existing PR branch (often `copilot/*`) — do not switch branches and do not create a new branch
 - If clarification is needed, ask via PR comments and wait (do not guess)
 
 **Example: Workflow Engineer**

--- a/docs/workflow/041-cloud-coding-agent-branch-awareness/tasks.md
+++ b/docs/workflow/041-cloud-coding-agent-branch-awareness/tasks.md
@@ -2,10 +2,10 @@
 
 | ID | Title | Source | Status | Rationale | Impact | Effort | Risk | Notes |
 |---:|---|---|---|---|---|---|---|---|
-| 1 | Document PR-coding-agent branch rules | user-report | ⬜ Not started | Cloud coding agents must not switch branches; doing so can lead to “no files in PR” even if work was done. | High | Low | Low | Update context docs to explicitly cover PR-based coding agent runs and branch constraints. |
+| 1 | Document PR-coding-agent branch rules | user-report | ✅ Done | Cloud coding agents must not switch branches; doing so can lead to “no files in PR” even if work was done. | High | Low | Low | Updated docs/agents.md and the execution-context-detection skill with explicit PR-coding-agent branch constraints and PR-comment clarification guidance. |
 | 2 | Update Workflow Engineer for cloud PR branch safety | user-report | ✅ Done | Workflow Engineer currently instructs switching/creating branches; in PR-coding-agent context this is harmful. | High | Low | Med | Add explicit guardrails: never `git switch` / create new branch in GitHub coding agent runs; work on the provided branch. |
 | 3 | Fix Requirements Engineer “made-up answers” via PR comments | user-report | ✅ Done | In GitHub coding agent runs, requirements clarifications must be asked via PR comments (or issue comments), not guessed and written into specs. | High | Med | Med | Add “no assumptions” rule: ask via PR comments; keep unknowns as Open Questions until answered. |
-| 4 | Align all agents on cloud branch constraints | prior-work | ⬜ Not started | Multiple agents contain branch-creation steps that are correct locally but wrong in cloud PR runs. | High | Med | High | Requires touching many agent files; do only if we want a broad fix. |
+| 4 | Align all agents on cloud branch constraints | prior-work | ✅ Done | Multiple agents contain branch-creation steps that are correct locally but wrong in cloud PR runs. | High | Med | High | Added consistent PR-coding-agent branch safety guidance across all agents; adjusted “Do NOT push” guidance to be VS Code-local only where it conflicted with PR-coding-agent updates. |
 
 ## Recommendations
 


### PR DESCRIPTION
## Problem
Cloud PR coding-agent runs can switch/create branches, leading to "work performed but no files added to the PR" because commits land elsewhere. Some agents also risk inventing requirements instead of asking for clarification.

## Change
- Document explicit PR-coding-agent constraints (stay on the provided PR branch; ask clarifying questions via PR comments).
- Align all agents with consistent "PR coding agent safety" guidance and make any "do not push" rules explicitly VS Code-local.
- Mark workflow work items as completed.

## Verification
- Ran `scripts/validate-agents.py`.
