### PR TITLE
fix: update Dockerfile path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: src/Dockerfile
           push: true
           tags: ${{ steps.docker_tags.outputs.tags }}
           cache-from: type=gha


### PR DESCRIPTION
The Dockerfile was moved to src/Dockerfile, but the release workflow still expected it in the root. This PR updates the path.
