### PR TITLE
ci: exclude docker tests from coverage-data

### DIFF
--- a/.github/workflows/coverage-data.yml
+++ b/.github/workflows/coverage-data.yml
@@ -40,7 +40,17 @@ jobs:
       - name: Test (with coverage)
         run: |
           chmod +x scripts/test-with-timeout.sh
-          scripts/test-with-timeout.sh --timeout-seconds 180 -- dotnet test --project src/tests/Oocx.TfPlan2Md.TUnit/ --configuration Release --results-directory ${{ github.workspace }}/TestResults -- --report-trx --coverage --coverage-output coverage.cobertura.xml --coverage-output-format cobertura
+          # Keep the post-merge coverage job fast and stable: exclude Docker-based tests.
+          scripts/test-with-timeout.sh --timeout-seconds 180 -- dotnet test \
+            --project src/tests/Oocx.TfPlan2Md.TUnit/ \
+            --configuration Release \
+            --results-directory ${{ github.workspace }}/TestResults \
+            --filter "FullyQualifiedName!~Oocx.TfPlan2Md.TUnit.Docker&FullyQualifiedName!~MarkdownLint" \
+            -- \
+            --report-trx \
+            --coverage \
+            --coverage-output coverage.cobertura.xml \
+            --coverage-output-format cobertura
 
       - name: Generate badge and history (staging)
         run: |


### PR DESCRIPTION
## Problem
The post-merge `Coverage Data` workflow can time out when Docker-based tests run, which prevents publishing coverage history/badges.

## Change
- Exclude Docker-based tests from the `Coverage Data` workflow's coverage run via `dotnet test --filter`.

## Verification
- Workflow YAML updated to filter out Docker-related tests for the coverage job.
