### PR TITLE
ci: fix TUnit filter in coverage-data

### DIFF
--- a/.github/workflows/coverage-data.yml
+++ b/.github/workflows/coverage-data.yml
@@ -45,8 +45,8 @@ jobs:
             --project src/tests/Oocx.TfPlan2Md.TUnit/ \
             --configuration Release \
             --results-directory ${{ github.workspace }}/TestResults \
-            --filter "FullyQualifiedName!~Oocx.TfPlan2Md.TUnit.Docker&FullyQualifiedName!~MarkdownLint" \
             -- \
+            --treenode-filter "/**[Category!=Docker]&[Category!=MarkdownLint]" \
             --report-trx \
             --coverage \
             --coverage-output coverage.cobertura.xml \


### PR DESCRIPTION
## Summary
Fixes the Coverage Data workflow failing during the test step.

## Problem
The workflow used `dotnet test --filter ...` (vstest syntax), but the repo’s TUnit runner does not support `--filter` and exits with `Unknown option '--filter'`.

## Change
- Switch to TUnit’s `--treenode-filter` (passed after `--`) and exclude Docker/MarkdownLint categories.

## Verification
- Observed failure in Actions run 21489422001: `Unknown option '--filter'`.
- Change aligns with documented TUnit usage (`--treenode-filter` after `--`).

## Notes
Once merged, the next `Coverage Data` run on `main` should be able to complete and publish the `coverage-data` branch.
