### PR TITLE
ci: fix coverage-data treenode-filter

### DIFF
--- a/.github/workflows/coverage-data.yml
+++ b/.github/workflows/coverage-data.yml
@@ -46,7 +46,7 @@ jobs:
             --configuration Release \
             --results-directory ${{ github.workspace }}/TestResults \
             -- \
-            --treenode-filter "/**[Category!=Docker]&[Category!=MarkdownLint]" \
+            --treenode-filter "/**[Category!=Docker]" \
             --report-trx \
             --coverage \
             --coverage-output coverage.cobertura.xml \


### PR DESCRIPTION
## Summary
Fixes the Coverage Data workflow failing during the test step.

## Problem
The Coverage Data workflow uses a TUnit `--treenode-filter` expression that crashes the test application parser, causing the job to fail and preventing publication to the `coverage-data` branch.

Failing run:
- https://github.com/oocx/tfplan2md/actions/runs/21494049325/job/61924008267

## Change
- Simplify the filter to a known-good expression: exclude only Docker tests (`/**[Category!=Docker]`).

## Verification
- The previous run fails with `TreeNodeFilter.ParseFilter` throwing `InvalidOperationException`.
- This change removes the problematic combined filter expression.
