### PR TITLE
ci: avoid releases for test-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
 
           # Paths that can affect the published Docker image
           releasable=$(echo "$changed" | grep -E '^(src/|examples/|dotnet-tools\.json$|\.dockerignore$)' || true)
+
+          # Exclude paths that do not change the published runtime image (but may still affect build/test).
+          # We intentionally do NOT create new tags/releases for test-only or generated test output changes.
+          releasable=$(echo "$releasable" | grep -Ev '^(src/tests/|src/tools/|src/TestResults/|src/src/TestResults/)' || true)
           if [ -z "$releasable" ]; then
             echo "Only non-release-impacting files changed since $last_tag; skipping versionize."
             echo "release_needed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
The post-merge Coverage Data workflow intentionally commits generated badge/history updates to `coverage-data`. Fixing that required touching `src/tests/...`, but our CI versioning workflow treats any `src/**` change as release-impacting.

That caused `ci.yml` to run Versionize, push a new `v*` tag, and trigger a release even though only tests changed.

## Changes
- Update `.github/workflows/ci.yml` release-impacting path detection to exclude:
  - `src/tests/**`
  - `src/TestResults/**`
  - `src/src/TestResults/**`

## Notes
- This does not change what files CI builds/tests; it only prevents automatic tagging/releases for test-only changes.
