### PR TITLE
fix: improve OpenSSF scorecard score

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 # CI Optimization: Tests removed from this workflow to eliminate redundancy.
 # All quality gates (format, build, test, lint, vulnerability scan) run in PR Validation.
@@ -28,6 +28,8 @@ jobs:
   version:
     name: Version and Tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,13 +10,14 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
-  checks: write
 
 jobs:
   validate:
     name: Validate PR
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      checks: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,7 +248,7 @@ jobs:
             rid: linux-x64
             archive_ext: tar.gz
             binary_name: tfplan2md
-            container: mcr.microsoft.com/dotnet/sdk:10.0-noble
+            container: mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:6d7f69bc7bc9d4510ca255977b1f53ce52a79307e048a91450b2aecd63627cc3
             needs_clang: true
             compress_with_upx: true
           - platform: linux-arm64
@@ -256,7 +256,7 @@ jobs:
             rid: linux-arm64
             archive_ext: tar.gz
             binary_name: tfplan2md
-            container: mcr.microsoft.com/dotnet/sdk:10.0-noble
+            container: mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:6d7f69bc7bc9d4510ca255977b1f53ce52a79307e048a91450b2aecd63627cc3
             needs_clang: true
             compress_with_upx: true
           # Alpine/musl builds (for Alpine Linux, Atlantis, and other musl-based environments)
@@ -357,7 +357,7 @@ jobs:
             -w /work \
             -e RID="${{ matrix.rid }}" \
             -e PLATFORM="${{ matrix.platform }}" \
-            mcr.microsoft.com/dotnet/sdk:10.0-alpine \
+            mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:828a5235b7df373cc96b5ca74a4823a19f9e1fea654abf01e1cb1dd9c767b718 \
             sh -c 'apk add --no-cache clang build-base zlib-dev linux-headers && dotnet publish src/Oocx.TfPlan2Md/Oocx.TfPlan2Md.csproj -c Release -r "$RID" --self-contained true -p:PublishAot=true -o "/work/artifacts/$PLATFORM"'
 
       - name: Fix artifact ownership (musl builds)
@@ -438,7 +438,7 @@ jobs:
           if [[ "${{ matrix.platform }}" == linux-musl-* ]]; then
             docker run --rm \
               -v "$(pwd)/artifacts/${{ matrix.platform }}:/musl_binary" \
-              mcr.microsoft.com/dotnet/runtime-deps:10.0-alpine \
+              mcr.microsoft.com/dotnet/runtime-deps:10.0-alpine@sha256:06c12910f2a94dfb35e70d6e5cc30f707ae54d91755979ae6cd5a7d004a27dfe \
               /musl_binary/${{ matrix.binary_name }} --help > /dev/null
           else
             artifacts/${{ matrix.platform }}/${{ matrix.binary_name }} --help > /dev/null

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - use Alpine SDK for musl compatibility
-FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:828a5235b7df373cc96b5ca74a4823a19f9e1fea654abf01e1cb1dd9c767b718 AS build
 WORKDIR /workspace
 
 # Copy all files

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -419,9 +419,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1215,9 +1215,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.25.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.0.tgz",
-      "integrity": "sha512-XpO7AiGULTG4xcTlwkcTI5JreFG7b6esLCLp+aUSh7YuQErJZEoUXre9u9rbdb0057pfWG4l0VursvLd5Q/eAw==",
+      "version": "10.25.7",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.7.tgz",
+      "integrity": "sha512-rPCjJLiD4eDhQjvv964AeXFC+HbeYBbZrd7Z82Q6hqv1lX7G+5w4SJcKLn9CAAAwHI4aS3dTdo083UB79K3pDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1542,9 +1542,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1747,9 +1747,9 @@
       }
     },
     "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

Improves the OpenSSF Scorecard score by addressing several security-related checks:

- **Token-Permissions**: Move token permissions from workflow level to job level following principle of least privilege
- **Pinned-Dependencies**: Pin Docker images to SHA256 digests to prevent supply chain attacks
- **Vulnerabilities**: Fix website dependencies (brace-expansion, liquidjs, picomatch)

## Expected Score Impact

| Check | Before | After |
|-------|--------|-------|
| Token-Permissions | 0 | 10 |
| Pinned-Dependencies | 7 | 10 |
| Vulnerabilities | 2 | 10 |
| **Overall** | ~5.8 | ~8-9 |