### PR TITLE
feat: enable multi-platform Docker image build (linux/amd64, linux/arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -691,6 +691,9 @@ jobs:
           echo -e "$TAGS" >> $GITHUB_OUTPUT
           echo EOF >> $GITHUB_OUTPUT
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -709,6 +712,7 @@ jobs:
         with:
           context: .
           file: src/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker_tags.outputs.tags }}
           labels: |

--- a/docs/features/657-multi-platform-image-build/release-notes.md
+++ b/docs/features/657-multi-platform-image-build/release-notes.md
@@ -1,0 +1,11 @@
+# Multi-Platform Docker Image Build (linux/amd64 + linux/arm64)
+
+The official Docker image is now published as a multi-platform manifest supporting both `linux/amd64` and `linux/arm64`. Pulls on ARM64 hosts (e.g., Apple Silicon, AWS Graviton, Raspberry Pi) will automatically receive a native binary without any extra flags.
+
+## ✨ Features
+
+- **ARM64 Docker image support.** The `ghcr.io/oocx/tfplan2md` image now includes a native `linux/arm64` layer alongside the existing `linux/amd64` layer. Docker automatically selects the right layer based on the host architecture.
+
+## 🔗 Commits
+
+- [`cc4de0cf`](https://github.com/oocx/tfplan2md/commit/cc4de0cf) feat: enable multi-platform Docker image build (linux/amd64, linux/arm64)

--- a/docs/features/657-multi-platform-image-build/work-protocol.md
+++ b/docs/features/657-multi-platform-image-build/work-protocol.md
@@ -1,0 +1,16 @@
+# Work Protocol: Multi-Platform Docker Image Build
+
+**Work Item:** `docs/features/657-multi-platform-image-build/`
+**Branch:** `oocx/feature-multi-platform-image-build`
+**Workflow Type:** Feature
+**Created:** 2026-05-19
+
+## Agent Work Log
+
+### Developer
+- **Date:** 2026-05-19
+- **Summary:** Added QEMU setup step and `platforms: linux/amd64,linux/arm64` to the Docker build-push step in `.github/workflows/release.yml`. Updated `src/Dockerfile` to use a manifest list digest and an arch-aware `dotnet publish` RID via `ARG TARGETARCH` so both platforms build correctly with NativeAOT.
+- **Artifacts Produced:**
+  - `.github/workflows/release.yml` (added `docker/setup-qemu-action`, added `platforms` to build-push step)
+  - `src/Dockerfile` (updated base image digest to manifest list; arch-aware `dotnet publish` RID)
+- **Problems Encountered:** None.

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,12 +1,15 @@
 # Build stage - use Alpine SDK for musl compatibility
-FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:828a5235b7df373cc96b5ca74a4823a19f9e1fea654abf01e1cb1dd9c767b718 AS build
+# Manifest list digest (multi-arch: linux/amd64, linux/arm/v7, linux/arm64); obtained via:
+#   docker buildx imagetools inspect mcr.microsoft.com/dotnet/sdk:10.0-alpine
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:5c559aa5d99337e400d39ab4fa1f6979d126c29b20939d53658ed38300571e74 AS build
 WORKDIR /workspace
 
 # Copy all files
 COPY . .
 
 # Install native toolchain prerequisites for NativeAOT (Alpine uses apk)
-# Versions pinned for reproducibility against Alpine 3.23 (base image digest pinned above).
+# Versions pinned for reproducibility against Alpine 3.23. Package versions are identical
+# across architectures on Alpine Linux.
 # To refresh versions: docker run --rm <base-image> sh -c \
 #   "apk info -v upx clang lld build-base zlib-dev linux-headers bash"
 RUN apk add --no-cache \
@@ -22,14 +25,21 @@ RUN apk add --no-cache \
 RUN dotnet restore src/tfplan2md.slnx
 RUN dotnet build src/tfplan2md.slnx --no-restore -c Release
 
-# Publish NativeAOT for linux-musl-x64 with static musl linking (no dynamic libc dependency)
-RUN dotnet publish src/Oocx.TfPlan2Md/Oocx.TfPlan2Md.csproj \
-    -c Release \
-    -r linux-musl-x64 \
-    --self-contained true \
-    -o /app/publish \
-    -p:StaticExecutable=true \
-    -p:LinkerFlavor=lld
+# Publish NativeAOT with static musl linking (no dynamic libc dependency).
+# TARGETARCH is set automatically by Docker Buildx for multi-platform builds.
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+      amd64) DOTNET_RID=linux-musl-x64 ;; \
+      arm64) DOTNET_RID=linux-musl-arm64 ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    dotnet publish src/Oocx.TfPlan2Md/Oocx.TfPlan2Md.csproj \
+      -c Release \
+      -r "${DOTNET_RID}" \
+      --self-contained true \
+      -o /app/publish \
+      -p:StaticExecutable=true \
+      -p:LinkerFlavor=lld
 
 RUN upx --ultra-brute /app/publish/tfplan2md
 


### PR DESCRIPTION
## Summary

Closes #657

Adds `linux/arm64` alongside `linux/amd64` to the Docker image published to Docker Hub, so ARM users can pull and run `oocx/tfplan2md` natively.

## Changes

### `.github/workflows/release.yml`
- Added `docker/setup-qemu-action@ce360397` (`v4.0.0`) step before `setup-buildx-action` — required for QEMU to emulate arm64 on GitHub's amd64 `ubuntu-latest` runner
- Added `platforms: linux/amd64,linux/arm64` to the `docker/build-push-action` step

### `src/Dockerfile`
- Updated base image from a stale platform-specific digest to the current **manifest list digest** (`sha256:5c559aa5…`) covering `linux/amd64`, `linux/arm/v7`, and `linux/arm64` — digest pinning is fully preserved (no security/OpenSSF regression)
- Added `ARG TARGETARCH` (auto-set by Docker Buildx) before the publish step
- Replaced hardcoded `-r linux-musl-x64` with a `case` expression: `amd64` → `linux-musl-x64`, `arm64` → `linux-musl-arm64`

## Notes
- Alpine apk package versions are identical across architectures — all pinned versions remain valid
- UPX 5.x supports aarch64 binaries — no change needed for the compression step
- The `FROM scratch` runtime stage is arch-agnostic
- arm64 images build via QEMU emulation on GitHub-hosted runners (slower but correct)